### PR TITLE
fix(core): clear stale interactive UI state between turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and ask-user-question
 - **hooks:** translate Claude Code hook events and tool matchers from
   `.claude/settings.json` so PreToolUse/PostToolUse/Stop hooks run in tallow
+- **tui:** clear stale working and queued steering/follow-up UI state on
+  turn end via interactive-mode runtime patch
 
 ### Removed
 

--- a/skills/tallow-expert/SKILL.md
+++ b/skills/tallow-expert/SKILL.md
@@ -33,7 +33,7 @@ Relay that answer to the user.
 
 | Component | Location |
 |-----------|----------|
-| Core source | `src/` (atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, sdk.ts, session-migration.ts, session-utils.ts) |
+| Core source | `src/` (atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, interactive-mode-patch.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, sdk.ts, session-migration.ts, session-utils.ts) |
 | Extensions | `extensions/` — extension.json + index.ts each (49 bundled) |
 | Skills | `skills/` — subdirs with SKILL.md |
 | Agents | `agents/` — markdown with YAML frontmatter |

--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+import { patchInteractiveModePrototype } from "../interactive-mode-patch.js";
+
+interface FakeEvent {
+	type?: string;
+}
+
+class FakeInteractiveMode {
+	defaultEditor: { onEscape?: () => void } = {};
+	escapeCalls = 0;
+	handleEventCalls = 0;
+	lastRestoredAbort: boolean | undefined;
+	loadingAnimation: unknown;
+	pendingWorkingMessage: unknown = "stale";
+	renderRequests = 0;
+	session = { isStreaming: false };
+	statusClears = 0;
+	updateCalls = 0;
+	ui = { requestRender: () => this.renderRequests++ };
+
+	/**
+	 * Base handleEvent implementation used by the patch wrapper.
+	 *
+	 * @param _event - Event payload
+	 * @returns Promise resolved with marker text
+	 */
+	async handleEvent(_event: FakeEvent): Promise<string> {
+		this.handleEventCalls++;
+		return "ok";
+	}
+
+	/**
+	 * Base setupKeyHandlers implementation that installs the default escape handler.
+	 *
+	 * @returns Nothing
+	 */
+	setupKeyHandlers(): void {
+		this.defaultEditor.onEscape = () => {
+			this.escapeCalls++;
+		};
+	}
+
+	/**
+	 * Snapshot current queued messages.
+	 *
+	 * @returns Queued steering/follow-up messages
+	 */
+	getAllQueuedMessages(): { followUp: string[]; steering: string[] } {
+		return { followUp: [], steering: [] };
+	}
+
+	/**
+	 * Restore queued messages to editor.
+	 *
+	 * @param options - Restore options
+	 * @returns True when restore executed
+	 */
+	restoreQueuedMessagesToEditor(options?: { abort?: boolean }): boolean {
+		this.lastRestoredAbort = options?.abort;
+		return true;
+	}
+
+	/**
+	 * Count display refresh calls.
+	 *
+	 * @returns Nothing
+	 */
+	updatePendingMessagesDisplay(): void {
+		this.updateCalls++;
+	}
+
+	statusContainer = {
+		clear: (): void => {
+			this.statusClears++;
+		},
+	};
+
+	/**
+	 * Build extension UI context with a setWorkingMessage implementation similar
+	 * to InteractiveMode.
+	 *
+	 * @returns Extension UI context object
+	 */
+	createExtensionUIContext(): { setWorkingMessage: (message?: string) => void } {
+		return {
+			setWorkingMessage: (message?: string): void => {
+				if (this.loadingAnimation) {
+					return;
+				}
+				this.pendingWorkingMessage = message;
+			},
+		};
+	}
+}
+
+describe("patchInteractiveModePrototype", () => {
+	it("applies agent_end cleanup without double-wrapping", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+
+		const mode = new FakeInteractiveMode();
+		const result = await mode.handleEvent({ type: "agent_end" });
+
+		expect(result).toBe("ok");
+		expect(mode.handleEventCalls).toBe(1);
+		expect(mode.pendingWorkingMessage).toBeUndefined();
+		expect(mode.statusClears).toBe(1);
+		expect(mode.updateCalls).toBe(1);
+		expect(mode.renderRequests).toBe(1);
+	});
+
+	it("restores queued messages on idle Escape", () => {
+		class QueuedEscapeMode extends FakeInteractiveMode {
+			override getAllQueuedMessages(): { followUp: string[]; steering: string[] } {
+				return { followUp: [], steering: ["stale steer"] };
+			}
+		}
+
+		patchInteractiveModePrototype(QueuedEscapeMode.prototype as never);
+		const mode = new QueuedEscapeMode();
+		mode.setupKeyHandlers();
+
+		expect(typeof mode.defaultEditor.onEscape).toBe("function");
+		mode.defaultEditor.onEscape?.();
+
+		expect(mode.escapeCalls).toBe(0);
+		expect(mode.lastRestoredAbort).toBe(false);
+	});
+
+	it("keeps original Escape behavior during active loading", () => {
+		class LoadingEscapeMode extends FakeInteractiveMode {
+			override getAllQueuedMessages(): { followUp: string[]; steering: string[] } {
+				return { followUp: [], steering: ["queued"] };
+			}
+		}
+
+		patchInteractiveModePrototype(LoadingEscapeMode.prototype as never);
+		const mode = new LoadingEscapeMode();
+		mode.loadingAnimation = { active: true };
+		mode.setupKeyHandlers();
+		mode.defaultEditor.onEscape?.();
+
+		expect(mode.escapeCalls).toBe(1);
+		expect(mode.lastRestoredAbort).toBeUndefined();
+	});
+
+	it("drops idle non-empty setWorkingMessage to avoid stale carryover", () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+		const uiContext = mode.createExtensionUIContext();
+
+		mode.pendingWorkingMessage = undefined;
+		uiContext.setWorkingMessage("late async message");
+		expect(mode.pendingWorkingMessage).toBeUndefined();
+
+		uiContext.setWorkingMessage();
+		expect(mode.pendingWorkingMessage).toBeUndefined();
+
+		mode.session.isStreaming = true;
+		uiContext.setWorkingMessage("queued while streaming");
+		expect(mode.pendingWorkingMessage).toBe("queued while streaming");
+	});
+});

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -1,0 +1,150 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+interface QueuedMessagesLike {
+	followUp?: unknown[];
+	steering?: unknown[];
+}
+
+interface InteractiveModeInstanceLike {
+	defaultEditor?: { onEscape?: (() => void) | undefined };
+	getAllQueuedMessages?: (() => QueuedMessagesLike) | undefined;
+	loadingAnimation?: unknown;
+	pendingWorkingMessage?: unknown;
+	restoreQueuedMessagesToEditor?: ((options?: { abort?: boolean }) => unknown) | undefined;
+	session?: { isStreaming?: boolean };
+	statusContainer?: { clear?: (() => void) | undefined };
+	ui?: { requestRender?: (() => void) | undefined };
+	updatePendingMessagesDisplay?: (() => void) | undefined;
+}
+
+interface InteractiveModePrototypeLike {
+	__tallow_stale_ui_patch_applied__?: boolean;
+	createExtensionUIContext?: ((...args: unknown[]) => Record<string, unknown>) | undefined;
+	handleEvent?: ((event: { type?: string }) => Promise<unknown>) | undefined;
+	setupKeyHandlers?: ((...args: unknown[]) => unknown) | undefined;
+}
+
+const APPLY_FLAG = "__tallow_interactive_stale_ui_patch_applied__";
+
+/**
+ * Returns whether queued steering/follow-up messages exist.
+ *
+ * @param messages - Queued messages snapshot
+ * @returns True when either steering or follow-up queue is non-empty
+ */
+function hasQueuedMessages(messages: QueuedMessagesLike | undefined): boolean {
+	if (!messages) return false;
+	const steeringCount = Array.isArray(messages.steering) ? messages.steering.length : 0;
+	const followUpCount = Array.isArray(messages.followUp) ? messages.followUp.length : 0;
+	return steeringCount > 0 || followUpCount > 0;
+}
+
+/**
+ * Patches InteractiveMode prototype methods to prevent stale UI carry-over.
+ *
+ * The patch adds:
+ * - agent_end cleanup for pending working messages + pending-message refresh
+ * - idle Escape behavior that clears queued steering/follow-up messages
+ * - setWorkingMessage guard so idle non-empty updates don't queue stale text
+ *
+ * @param prototype - InteractiveMode prototype object
+ * @returns Nothing
+ */
+export function patchInteractiveModePrototype(prototype: InteractiveModePrototypeLike): void {
+	if (prototype.__tallow_stale_ui_patch_applied__) return;
+	prototype.__tallow_stale_ui_patch_applied__ = true;
+
+	const originalHandleEvent = prototype.handleEvent;
+	if (typeof originalHandleEvent === "function") {
+		prototype.handleEvent = async function (this: InteractiveModeInstanceLike, event) {
+			const result = await originalHandleEvent.call(this, event);
+			if (event?.type === "agent_end") {
+				this.pendingWorkingMessage = undefined;
+				this.statusContainer?.clear?.();
+				this.updatePendingMessagesDisplay?.();
+				this.ui?.requestRender?.();
+			}
+			return result;
+		};
+	}
+
+	const originalSetupKeyHandlers = prototype.setupKeyHandlers;
+	if (typeof originalSetupKeyHandlers === "function") {
+		prototype.setupKeyHandlers = function (this: InteractiveModeInstanceLike, ...args: unknown[]) {
+			const result = originalSetupKeyHandlers.call(this, ...args);
+			const editor = this.defaultEditor;
+			const existingEscape = editor?.onEscape;
+			if (editor && typeof existingEscape === "function") {
+				editor.onEscape = () => {
+					const queued = this.getAllQueuedMessages?.();
+					if (!this.loadingAnimation && hasQueuedMessages(queued)) {
+						this.restoreQueuedMessagesToEditor?.({ abort: false });
+						return;
+					}
+					existingEscape();
+				};
+			}
+			return result;
+		};
+	}
+
+	const originalCreateExtensionUIContext = prototype.createExtensionUIContext;
+	if (typeof originalCreateExtensionUIContext === "function") {
+		prototype.createExtensionUIContext = function (
+			this: InteractiveModeInstanceLike,
+			...args: unknown[]
+		) {
+			const context = originalCreateExtensionUIContext.call(this, ...args);
+			const originalSetWorkingMessage = context.setWorkingMessage;
+			if (typeof originalSetWorkingMessage === "function") {
+				context.setWorkingMessage = (message?: string) => {
+					const hasLoader = Boolean(this.loadingAnimation);
+					const isStreaming = Boolean(this.session?.isStreaming);
+					if (!hasLoader && !isStreaming && typeof message === "string" && message.length > 0) {
+						return;
+					}
+					(originalSetWorkingMessage as (value?: string) => unknown)(message);
+				};
+			}
+			return context;
+		};
+	}
+}
+
+/**
+ * Applies the stale UI patch to pi-coding-agent InteractiveMode.
+ *
+ * Uses a direct file import via resolved package path because the InteractiveMode
+ * subpath is not exported from the package.
+ *
+ * @returns Nothing
+ */
+export async function applyInteractiveModeStaleUiPatch(): Promise<void> {
+	const globals = globalThis as Record<string, unknown>;
+	if (globals[APPLY_FLAG] === true) return;
+
+	try {
+		const require = createRequire(import.meta.url);
+		const packageJsonPath = require.resolve("@mariozechner/pi-coding-agent/package.json");
+		const packageRoot = dirname(packageJsonPath);
+		const interactiveModePath = join(
+			packageRoot,
+			"dist",
+			"modes",
+			"interactive",
+			"interactive-mode.js"
+		);
+		const moduleUrl = pathToFileURL(interactiveModePath).href;
+		const mod = (await import(moduleUrl)) as {
+			InteractiveMode?: { prototype?: InteractiveModePrototypeLike };
+		};
+		const prototype = mod.InteractiveMode?.prototype;
+		if (!prototype) return;
+		patchInteractiveModePrototype(prototype);
+		globals[APPLY_FLAG] = true;
+	} catch {
+		// Non-fatal: patching is a runtime compatibility improvement.
+	}
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -28,6 +28,7 @@ import { setNextImageFilePath } from "@mariozechner/pi-tui";
 import { atomicWriteFileSync } from "./atomic-write.js";
 import { resolveRuntimeApiKeyFromEnv, SecureAuthStorage } from "./auth-hardening.js";
 import { BUNDLED, bootstrap, resolveOpSecrets, TALLOW_HOME, TALLOW_VERSION } from "./config.js";
+import { applyInteractiveModeStaleUiPatch } from "./interactive-mode-patch.js";
 import { cleanupOrphanPids } from "./pid-manager.js";
 import { extractClaudePluginResources, type ResolvedPlugin, resolvePlugins } from "./plugins.js";
 import { migrateSessionsToPerCwdDirs } from "./session-migration.js";
@@ -257,6 +258,7 @@ export async function createTallowSession(
 	// Ensure env is configured before any framework internals resolve paths
 	bootstrap();
 	ensureTallowHome();
+	await applyInteractiveModeStaleUiPatch();
 
 	// Resolve any op:// secrets not loaded from cache during bootstrap.
 	// Runs in parallel (~2.4s for all) instead of sequential (~2.4s each).


### PR DESCRIPTION
## Summary
- patch InteractiveMode runtime to clear stale working/pending UI state on agent_end
- prevent idle non-empty setWorkingMessage calls from queuing stale carry-over text
- allow Escape to restore queued steering/follow-up messages when idle
- add focused unit tests for patch behavior

## Validation
- bun test src/__tests__/interactive-mode-patch.test.ts
- bun run typecheck
- bun run typecheck:extensions
- bun run build
- bun test extensions/__integration__
- bun run format:check
- node tests/docs-drift.mjs
