### PR TITLE
fix: scope orphan PID cleanup by live owner identity

### DIFF
--- a/extensions/_shared/__tests__/pid-registry.test.ts
+++ b/extensions/_shared/__tests__/pid-registry.test.ts
@@ -40,6 +40,8 @@ function readRawPidFile(): {
 	entries: Array<{
 		pid: number;
 		command: string;
+		ownerPid?: number;
+		ownerStartedAt?: string;
 		processStartedAt?: string;
 		startedAt: number;
 	}>;
@@ -111,7 +113,11 @@ describe("pid-registry", () => {
 			expect(file.entries).toHaveLength(1);
 			expect(file.entries[0].pid).toBe(12345);
 			expect(file.entries[0].command).toBe("npm test");
+			expect(file.entries[0].ownerPid).toBe(process.pid);
 			expect(typeof file.entries[0].startedAt).toBe("number");
+			if (file.entries[0].ownerStartedAt !== undefined) {
+				expect(typeof file.entries[0].ownerStartedAt).toBe("string");
+			}
 			if (file.entries[0].processStartedAt !== undefined) {
 				expect(typeof file.entries[0].processStartedAt).toBe("string");
 			}


### PR DESCRIPTION
## Summary
- extend PID registry entries with owner identity metadata (ownerPid, ownerStartedAt)
- make startup orphan cleanup skip entries owned by live sessions
- fail safe when owner metadata is missing and prune PID files selectively instead of unlinking wholesale
- add regression coverage for live-owner preservation and selective pruning

## Testing
- bun test src/__tests__/pid-manager.test.ts extensions/_shared/__tests__/pid-registry.test.ts
- bun run typecheck
- bun run lint