### PR TITLE
fix: make LSP test mocks hermetic across suites

### DIFF
--- a/extensions/lsp/__tests__/lsp-tools.test.ts
+++ b/extensions/lsp/__tests__/lsp-tools.test.ts
@@ -1,17 +1,20 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { ExtensionHarness } from "../../../test-utils/extension-harness.js";
-import { setupLspMockRuntime } from "./mock-lsp-runtime.js";
+import {
+	type LspMockRuntime,
+	setupLspMockRuntime,
+	teardownLspMockRuntime,
+} from "./mock-lsp-runtime.js";
 
-const runtime = setupLspMockRuntime();
-const {
-	default: lspExtension,
-	resetLspStateForTests,
-	setLspTimeoutsForTests,
-} = await import("../index.js");
+let runtime: LspMockRuntime;
+let lspExtension: typeof import("../index.js").default;
+let resetLspStateForTests: typeof import("../index.js").resetLspStateForTests;
+let setLspSpawnForTests: typeof import("../index.js").setLspSpawnForTests;
+let setLspTimeoutsForTests: typeof import("../index.js").setLspTimeoutsForTests;
 
 /**
  * Creates a minimal context for tool execution.
@@ -78,9 +81,23 @@ describe("lsp tool behavior with timeout guards", () => {
 	let harness: ExtensionHarness;
 	let projectDir: string;
 
+	beforeAll(async () => {
+		runtime = setupLspMockRuntime();
+		const mod = await import(`../index.js?t=${Date.now()}`);
+		lspExtension = mod.default;
+		resetLspStateForTests = mod.resetLspStateForTests;
+		setLspSpawnForTests = mod.setLspSpawnForTests;
+		setLspTimeoutsForTests = mod.setLspTimeoutsForTests;
+	});
+
+	afterAll(() => {
+		teardownLspMockRuntime();
+	});
+
 	beforeEach(async () => {
 		runtime.reset();
 		resetLspStateForTests();
+		setLspSpawnForTests(runtime.spawn);
 		setLspTimeoutsForTests({ requestMs: 40, startupMs: 50 });
 
 		projectDir = mkdtempSync(join(tmpdir(), "tallow-lsp-tools-"));

--- a/src/__tests__/pid-manager.test.ts
+++ b/src/__tests__/pid-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -34,6 +34,10 @@ beforeAll(async () => {
 	mkdirSync(sessionPidDir, { recursive: true });
 	process.env.TALLOW_HOME = tmpDir;
 
+	mock.module("../config.js", () => ({
+		TALLOW_HOME: tmpDir,
+	}));
+
 	const mod = await import(`../pid-manager.js?t=${Date.now()}`);
 	cleanupAllTrackedPidsFn = mod.cleanupAllTrackedPids;
 	cleanupOrphanPidsFn = mod.cleanupOrphanPids;
@@ -54,6 +58,8 @@ afterEach(() => {
 afterAll(() => {
 	rmSync(tmpDir, { recursive: true, force: true });
 	delete process.env.TALLOW_HOME;
+	mock.restore();
+	mock.clearAllMocks();
 });
 
 /**


### PR DESCRIPTION
## Summary
- stop globally mocking node:child_process in LSP tests and inject a scoped spawn implementation instead
- add explicit LSP mock runtime teardown and suite-level setup/cleanup to avoid module-state leakage
- harden fake child-process compatibility (ref/unref + spawn signature passthrough) for mixed-suite runs
- make pid-manager tests mock TALLOW_HOME config import explicitly to avoid import-order coupling in full-suite runs

## Testing
- bun test extensions/lsp/__tests__/lsp-tools.test.ts extensions/background-task-tool/__tests__/lifecycle.test.ts
- bun test extensions/lsp/__tests__/lsp-timeouts.test.ts extensions/hooks/__tests__/subprocess-hardening.test.ts
- bun test
- bun run typecheck
- bun run typecheck:extensions
- bun run lint