### PR TITLE
refactor: centralize test mock lifecycle with shared harness

### DIFF
--- a/extensions/lsp/__tests__/lsp-tools.test.ts
+++ b/extensions/lsp/__tests__/lsp-tools.test.ts
@@ -13,6 +13,7 @@ import {
 let runtime: LspMockRuntime;
 let lspExtension: typeof import("../index.js").default;
 let resetLspStateForTests: typeof import("../index.js").resetLspStateForTests;
+let setLspProtocolBindingsForTests: typeof import("../index.js").setLspProtocolBindingsForTests;
 let setLspSpawnForTests: typeof import("../index.js").setLspSpawnForTests;
 let setLspTimeoutsForTests: typeof import("../index.js").setLspTimeoutsForTests;
 
@@ -86,6 +87,7 @@ describe("lsp tool behavior with timeout guards", () => {
 		const mod = await import(`../index.js?t=${Date.now()}`);
 		lspExtension = mod.default;
 		resetLspStateForTests = mod.resetLspStateForTests;
+		setLspProtocolBindingsForTests = mod.setLspProtocolBindingsForTests;
 		setLspSpawnForTests = mod.setLspSpawnForTests;
 		setLspTimeoutsForTests = mod.setLspTimeoutsForTests;
 	});
@@ -97,6 +99,7 @@ describe("lsp tool behavior with timeout guards", () => {
 	beforeEach(async () => {
 		runtime.reset();
 		resetLspStateForTests();
+		setLspProtocolBindingsForTests(runtime.protocol);
 		setLspSpawnForTests(runtime.spawn);
 		setLspTimeoutsForTests({ requestMs: 40, startupMs: 50 });
 

--- a/test-utils/fake-child-process.ts
+++ b/test-utils/fake-child-process.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+interface FakeChildProcessOptions {
+	readonly onKill?: () => void;
+}
+
+/**
+ * Spawn-compatible fake child process for deterministic tests.
+ */
+export class FakeChildProcess extends EventEmitter {
+	readonly stderr = new PassThrough();
+	readonly stdin = new PassThrough();
+	readonly stdout = new PassThrough();
+
+	private killed = false;
+
+	constructor(private readonly options?: FakeChildProcessOptions) {
+		super();
+	}
+
+	/**
+	 * Simulate process termination.
+	 *
+	 * @param _signal - Optional signal (ignored in fake implementation)
+	 * @returns Always true
+	 */
+	kill(_signal?: NodeJS.Signals | number): boolean {
+		if (this.killed) {
+			return true;
+		}
+		this.killed = true;
+		this.options?.onKill?.();
+		this.emit("exit", null);
+		this.emit("close", 0);
+		return true;
+	}
+
+	/**
+	 * Compatibility no-op matching Node child process API.
+	 *
+	 * @returns This instance
+	 */
+	ref(): this {
+		return this;
+	}
+
+	/**
+	 * Compatibility no-op matching Node child process API.
+	 *
+	 * @returns This instance
+	 */
+	unref(): this {
+		return this;
+	}
+
+	/**
+	 * Emit a close event with a specific exit code.
+	 *
+	 * @param code - Exit code for the close event
+	 * @returns Nothing
+	 */
+	emitClose(code: number): void {
+		this.emit("close", code);
+	}
+
+	/**
+	 * Emit an error event with a normalized Error value.
+	 *
+	 * @param error - Error-like value to emit
+	 * @returns Nothing
+	 */
+	emitError(error: unknown): void {
+		const normalized =
+			error instanceof Error ? error : new Error(typeof error === "string" ? error : String(error));
+		this.emit("error", normalized);
+	}
+}

--- a/test-utils/index.ts
+++ b/test-utils/index.ts
@@ -14,6 +14,7 @@ export type {
 } from "./extension-harness.js";
 // Extension testing
 export { ExtensionHarness } from "./extension-harness.js";
+export { FakeChildProcess } from "./fake-child-process.js";
 export type { ScriptedResponse, TextResponse, ToolCallResponse } from "./mock-model.js";
 // Mock model and stream functions
 export {
@@ -21,6 +22,8 @@ export {
 	createMockModel,
 	createScriptedStreamFn,
 } from "./mock-model.js";
+export type { MockScope } from "./mock-scope.js";
+export { createMockScope } from "./mock-scope.js";
 export type { RunResult, SessionRunnerOptions } from "./session-runner.js";
 // Session runner
 export { createSessionRunner, SessionRunner } from "./session-runner.js";

--- a/test-utils/mock-scope.ts
+++ b/test-utils/mock-scope.ts
@@ -1,0 +1,68 @@
+import { mock } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+interface ModuleMockRegistration {
+	readonly factory: () => unknown;
+	readonly specifier: string;
+}
+
+export interface MockScope {
+	/**
+	 * Register a module mock factory in this scope.
+	 *
+	 * @param specifier - Module specifier passed to `mock.module`
+	 * @param factory - Mock module factory
+	 * @returns Nothing
+	 */
+	module: (specifier: string, factory: () => unknown) => void;
+	/**
+	 * Install all registered module mocks.
+	 *
+	 * @returns Nothing
+	 */
+	install: () => void;
+	/**
+	 * Restore Bun mocks and clear all spy state for this scope.
+	 *
+	 * @returns Nothing
+	 */
+	teardown: () => void;
+}
+
+/**
+ * Create a reusable module-mock scope for Bun test suites.
+ *
+ * The scope centralizes mock registration and teardown so suites can avoid
+ * ad-hoc `mock.restore()` calls scattered across files.
+ *
+ * @param baseUrl - Optional caller `import.meta.url` for resolving relative specifiers
+ * @returns Mock scope helper
+ */
+export function createMockScope(baseUrl?: string): MockScope {
+	const registrations: ModuleMockRegistration[] = [];
+	let installed = false;
+
+	return {
+		module(specifier: string, factory: () => unknown): void {
+			const resolvedSpecifier =
+				baseUrl && specifier.startsWith(".")
+					? fileURLToPath(new URL(specifier, baseUrl))
+					: specifier;
+			registrations.push({ factory, specifier: resolvedSpecifier });
+		},
+		install(): void {
+			if (installed) {
+				return;
+			}
+			for (const registration of registrations) {
+				mock.module(registration.specifier, registration.factory);
+			}
+			installed = true;
+		},
+		teardown(): void {
+			mock.restore();
+			mock.clearAllMocks();
+			installed = false;
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- add test-utils/mock-scope.ts to centralize Bun module mock install/teardown
- add test-utils/fake-child-process.ts for spawn-compatible child-process stubs (kill/ref/unref)
- refactor LSP test runtime to use injected protocol bindings + scoped spawn without global child_process mocks
- integrate setLspProtocolBindingsForTests and setLspSpawnForTests hooks in LSP extension tests
- migrate subagent routing tests to the shared mock-scope utility

## Testing
- bun test extensions/lsp/__tests__
- bun test extensions/background-task-tool/__tests__/lifecycle.test.ts
- bun test extensions/hooks/__tests__/subprocess-hardening.test.ts
- bun test extensions/subagent-tool/__tests__/auto-cheap-model.test.ts
- bun test
- bun run typecheck
- bun run typecheck:extensions
- bun run lint