### PR TITLE
refactor: centralize bg_bash subprocess lifecycle handling

### DIFF
--- a/extensions/background-task-tool/__tests__/process-lifecycle.test.ts
+++ b/extensions/background-task-tool/__tests__/process-lifecycle.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { createProcessLifecycle } from "../process-lifecycle.js";
+
+/**
+ * Minimal spawn-compatible fake child process for lifecycle tests.
+ */
+class FakeLifecycleChild extends EventEmitter {
+	readonly stderr = new PassThrough();
+	readonly stdin = new PassThrough();
+	readonly stdout = new PassThrough();
+	pid = 77_123;
+	killCount = 0;
+	unrefCount = 0;
+
+	/**
+	 * Simulate process kill and emit close.
+	 *
+	 * @returns Always true
+	 */
+	kill(): boolean {
+		this.killCount += 1;
+		this.emit("close", null);
+		return true;
+	}
+
+	/**
+	 * Track detach calls.
+	 *
+	 * @returns This child instance
+	 */
+	unref(): this {
+		this.unrefCount += 1;
+		return this;
+	}
+}
+
+/**
+ * Child-process fake intentionally lacking `unref`.
+ */
+class FakeChildWithoutUnref extends EventEmitter {
+	readonly stderr = new PassThrough();
+	readonly stdin = new PassThrough();
+	readonly stdout = new PassThrough();
+	pid = 11_222;
+
+	/**
+	 * Simulate process kill and emit close.
+	 *
+	 * @returns Always true
+	 */
+	kill(): boolean {
+		this.emit("close", null);
+		return true;
+	}
+}
+
+describe("process lifecycle helper", () => {
+	it("captures output and resolves close events", async () => {
+		const child = new FakeLifecycleChild();
+		const chunks: string[] = [];
+		const lifecycle = createProcessLifecycle({
+			child: child as unknown as ChildProcess,
+			onData: (chunk) => chunks.push(chunk.toString()),
+		});
+
+		child.stdout.write("hello");
+		child.stdout.write(" world");
+		child.emit("close", 0);
+
+		const result = await lifecycle.waitForExit();
+		expect(result).toEqual({ type: "close", code: 0 });
+		expect(chunks.join("")).toBe("hello world");
+	});
+
+	it("detach is safe when child has no unref method", () => {
+		const child = new FakeChildWithoutUnref();
+		const lifecycle = createProcessLifecycle({
+			child: child as unknown as ChildProcess,
+		});
+
+		expect(() => lifecycle.detach()).not.toThrow();
+	});
+
+	it("resolves timeout once and kills process", async () => {
+		const child = new FakeLifecycleChild();
+		const lifecycle = createProcessLifecycle({
+			child: child as unknown as ChildProcess,
+			timeoutMs: 5,
+		});
+
+		const result = await lifecycle.waitForExit();
+		expect(result).toEqual({ type: "timeout" });
+		expect(child.killCount).toBe(1);
+	});
+
+	it("resolves abort once and kills process", async () => {
+		const child = new FakeLifecycleChild();
+		const controller = new AbortController();
+		const lifecycle = createProcessLifecycle({
+			child: child as unknown as ChildProcess,
+			signal: controller.signal,
+		});
+
+		controller.abort();
+		const result = await lifecycle.waitForExit();
+		expect(result).toEqual({ type: "aborted" });
+		expect(child.killCount).toBe(1);
+	});
+
+	it("settles only once when error and close race", async () => {
+		const child = new FakeLifecycleChild();
+		const lifecycle = createProcessLifecycle({
+			child: child as unknown as ChildProcess,
+		});
+
+		child.emit("error", new Error("boom"));
+		child.emit("close", 0);
+
+		const result = await lifecycle.waitForExit();
+		expect(result.type).toBe("error");
+		if (result.type === "error") {
+			expect(result.error.message).toBe("boom");
+		}
+	});
+});

--- a/extensions/background-task-tool/process-lifecycle.ts
+++ b/extensions/background-task-tool/process-lifecycle.ts
@@ -1,0 +1,164 @@
+import type { ChildProcess } from "node:child_process";
+
+/** Result emitted when a managed child process completes or is interrupted. */
+export type ProcessLifecycleResult =
+	| { type: "close"; code: number | null }
+	| { type: "error"; error: Error }
+	| { type: "aborted" }
+	| { type: "timeout" };
+
+/** Options for process lifecycle management. */
+export interface ProcessLifecycleOptions {
+	readonly child: ChildProcess;
+	readonly onAbort?: () => void;
+	readonly onData?: (chunk: Buffer) => void;
+	readonly onTimeout?: () => void;
+	readonly signal?: AbortSignal;
+	readonly timeoutMs?: number;
+}
+
+/** Handle for interacting with a managed process lifecycle. */
+export interface ProcessLifecycleHandle {
+	/** Detach the child from the parent event loop when supported. */
+	detach(): void;
+	/** Await process completion/termination outcome. */
+	waitForExit(): Promise<ProcessLifecycleResult>;
+}
+
+/**
+ * Normalize unknown error-like values into Error instances.
+ *
+ * @param value - Unknown thrown or emitted error value
+ * @returns Normalized Error instance
+ */
+function toError(value: unknown): Error {
+	if (value instanceof Error) {
+		return value;
+	}
+	if (typeof value === "string") {
+		return new Error(value);
+	}
+	return new Error(String(value));
+}
+
+/**
+ * Normalize stream chunks to Buffer values.
+ *
+ * @param chunk - Stream chunk value
+ * @returns Buffer representation of the chunk
+ */
+function toBuffer(chunk: Buffer | string): Buffer {
+	return Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+}
+
+/**
+ * Manage child process lifecycle events with deterministic single settlement.
+ *
+ * Handles stream wiring, timeout/abort transitions, and listener cleanup.
+ * The first terminal event wins; later events are ignored.
+ *
+ * @param options - Lifecycle options and callbacks
+ * @returns Lifecycle handle for detach + completion await
+ */
+export function createProcessLifecycle(options: ProcessLifecycleOptions): ProcessLifecycleHandle {
+	const { child, onAbort, onData, onTimeout, signal, timeoutMs } = options;
+
+	let settled = false;
+	let timeoutHandle: NodeJS.Timeout | undefined;
+	let resolveWait: (result: ProcessLifecycleResult) => void;
+
+	const onStdout = (chunk: Buffer | string) => {
+		onData?.(toBuffer(chunk));
+	};
+	const onStderr = (chunk: Buffer | string) => {
+		onData?.(toBuffer(chunk));
+	};
+
+	const removeDataListeners = () => {
+		child.stdout?.removeListener("data", onStdout);
+		child.stderr?.removeListener("data", onStderr);
+	};
+
+	const cleanup = () => {
+		if (timeoutHandle) {
+			clearTimeout(timeoutHandle);
+			timeoutHandle = undefined;
+		}
+		if (signal && abortHandler) {
+			signal.removeEventListener("abort", abortHandler);
+		}
+		removeDataListeners();
+		child.removeListener("close", closeHandler);
+		child.removeListener("error", errorHandler);
+	};
+
+	const settle = (result: ProcessLifecycleResult): void => {
+		if (settled) {
+			return;
+		}
+		settled = true;
+		cleanup();
+		resolveWait(result);
+	};
+
+	const closeHandler = (code: number | null) => {
+		settle({ type: "close", code });
+	};
+	const errorHandler = (error: unknown) => {
+		settle({ type: "error", error: toError(error) });
+	};
+
+	const abortHandler = () => {
+		onAbort?.();
+		settle({ type: "aborted" });
+		try {
+			child.kill("SIGTERM");
+		} catch {
+			// Process may already be gone.
+		}
+	};
+
+	const waitForExit = new Promise<ProcessLifecycleResult>((resolve) => {
+		resolveWait = resolve;
+	});
+
+	child.stdout?.on("data", onStdout);
+	child.stderr?.on("data", onStderr);
+	child.on("close", closeHandler);
+	child.on("error", errorHandler);
+
+	if (signal?.aborted) {
+		abortHandler();
+	} else if (signal) {
+		signal.addEventListener("abort", abortHandler);
+	}
+
+	if (typeof timeoutMs === "number" && timeoutMs > 0) {
+		timeoutHandle = setTimeout(() => {
+			onTimeout?.();
+			settle({ type: "timeout" });
+			try {
+				child.kill("SIGTERM");
+			} catch {
+				// Process may already be gone.
+			}
+		}, timeoutMs);
+	}
+
+	const exitedWithCode = typeof child.exitCode === "number";
+	const exitedBySignal = child.signalCode != null;
+	if (exitedWithCode || exitedBySignal) {
+		settle({ type: "close", code: exitedWithCode ? child.exitCode : null });
+	}
+
+	return {
+		detach(): void {
+			if (typeof child.unref === "function") {
+				child.unref();
+			}
+		},
+		waitForExit(): Promise<ProcessLifecycleResult> {
+			return waitForExit;
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- extract process lifecycle orchestration into extensions/background-task-tool/process-lifecycle.ts
- centralize stream wiring, timeout/abort transitions, detach handling, and terminal-event settlement
- refactor bg_bash execution path to consume the lifecycle helper for both streaming and detached modes
- add focused helper tests for timeout/abort/race handling and compatibility with missing unref

## Testing
- bun test extensions/background-task-tool/__tests__/lifecycle.test.ts extensions/background-task-tool/__tests__/utils.test.ts extensions/background-task-tool/__tests__/process-lifecycle.test.ts
- bun run typecheck:extensions
- bun run lint