### PR TITLE
refactor: introduce runtime path provider and pid path injection

### DIFF
--- a/extensions/_shared/__tests__/pid-registry.test.ts
+++ b/extensions/_shared/__tests__/pid-registry.test.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { createStaticRuntimePathProvider } from "../../../src/runtime-path-provider.js";
 
 // Set env before importing the module under test (it reads TALLOW_CODING_AGENT_DIR at call time)
 let tmpDir: string;
@@ -34,8 +35,11 @@ afterEach(() => {
 // Dynamic import so each test gets the env var set above
 async function loadModule() {
 	// Bust the module cache by using a unique query string
-	const mod = await import(`../pid-registry.js?t=${Date.now()}`);
-	return mod as typeof import("../pid-registry.js");
+	const mod = (await import(
+		`../pid-registry.js?t=${Date.now()}`
+	)) as typeof import("../pid-registry.js");
+	mod.setPidRegistryPathProviderForTests(createStaticRuntimePathProvider(tmpDir));
+	return mod;
 }
 
 /**

--- a/skills/tallow-expert/SKILL.md
+++ b/skills/tallow-expert/SKILL.md
@@ -33,7 +33,7 @@ Relay that answer to the user.
 
 | Component | Location |
 |-----------|----------|
-| Core source | `src/` (agent-runner.ts, atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, interactive-mode-patch.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, project-trust.ts, sdk.ts, session-migration.ts, session-utils.ts) |
+| Core source | `src/` (agent-runner.ts, atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, interactive-mode-patch.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, project-trust.ts, runtime-path-provider.ts, sdk.ts, session-migration.ts, session-utils.ts) |
 | Extensions | `extensions/` — extension.json + index.ts each (49 bundled) |
 | Skills | `skills/` — subdirs with SKILL.md |
 | Agents | `agents/` — markdown with YAML frontmatter |

--- a/src/__tests__/runtime-path-provider.test.ts
+++ b/src/__tests__/runtime-path-provider.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createRuntimePathProvider,
+	createStaticRuntimePathProvider,
+} from "../runtime-path-provider.js";
+
+describe("runtime path provider", () => {
+	test("builds expected pid and trust paths from home resolver", () => {
+		const provider = createRuntimePathProvider(() => "/tmp/tallow-home");
+
+		expect(provider.getHomeDir()).toBe("/tmp/tallow-home");
+		expect(provider.getRunDir()).toBe("/tmp/tallow-home/run");
+		expect(provider.getLegacyPidFilePath()).toBe("/tmp/tallow-home/run/pids.json");
+		expect(provider.getSessionPidDir()).toBe("/tmp/tallow-home/run/pids");
+		expect(provider.getTrustDir()).toBe("/tmp/tallow-home/trust");
+		expect(provider.getProjectTrustStorePath()).toBe("/tmp/tallow-home/trust/projects.json");
+	});
+
+	test("re-reads resolver values on each call", () => {
+		let home = "/tmp/home-a";
+		const provider = createRuntimePathProvider(() => home);
+
+		expect(provider.getSessionPidDir()).toBe("/tmp/home-a/run/pids");
+		home = "/tmp/home-b";
+		expect(provider.getSessionPidDir()).toBe("/tmp/home-b/run/pids");
+	});
+
+	test("supports static providers for deterministic tests", () => {
+		const provider = createStaticRuntimePathProvider("/tmp/static-home");
+		expect(provider.getLegacyPidFilePath()).toBe("/tmp/static-home/run/pids.json");
+	});
+
+	test("throws for empty runtime home values", () => {
+		const provider = createRuntimePathProvider(() => "");
+		expect(() => provider.getHomeDir()).toThrow("non-empty home directory");
+	});
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRuntimePathProvider, type RuntimePathProvider } from "./runtime-path-provider.js";
 
 // ─── Identity ────────────────────────────────────────────────────────────────
 
@@ -26,6 +27,31 @@ export const TALLOW_HOME = resolveTallowHome();
  */
 export function getRuntimeTallowHome(): string {
 	return process.env.TALLOW_HOME || TALLOW_HOME;
+}
+
+/** Default runtime path provider bound to runtime home lookups. */
+const defaultRuntimePathProvider = createRuntimePathProvider(() => getRuntimeTallowHome());
+
+/** Optional runtime path provider override for tests and embedded SDK hosts. */
+let runtimePathProviderOverride: RuntimePathProvider | null = null;
+
+/**
+ * Resolve the active runtime path provider.
+ *
+ * @returns Runtime path provider for home-scoped directories/files
+ */
+export function getRuntimePathProvider(): RuntimePathProvider {
+	return runtimePathProviderOverride ?? defaultRuntimePathProvider;
+}
+
+/**
+ * Override the runtime path provider for tests.
+ *
+ * @param provider - Optional provider override (reset when omitted)
+ * @returns Nothing
+ */
+export function setRuntimePathProviderForTests(provider?: RuntimePathProvider): void {
+	runtimePathProviderOverride = provider ?? null;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,11 @@ export {
 	BUNDLED,
 	bootstrap,
 	CONFIG_DIR,
+	getRuntimePathProvider,
 	getRuntimeTallowHome,
 	isDemoMode,
 	sanitizePath,
+	setRuntimePathProviderForTests,
 	TALLOW_HOME,
 	TALLOW_VERSION,
 } from "./config.js";
@@ -56,6 +58,12 @@ export {
 	resolvePlugins,
 	type TallowExtensionManifest,
 } from "./plugins.js";
+export {
+	createRuntimePathProvider,
+	createStaticRuntimePathProvider,
+	type RuntimeHomeResolver,
+	type RuntimePathProvider,
+} from "./runtime-path-provider.js";
 export { createTallowSession, type TallowSession, type TallowSessionOptions } from "./sdk.js";
 export { createSessionWithId, findSessionById } from "./session-utils.js";
 

--- a/src/pid-manager.ts
+++ b/src/pid-manager.ts
@@ -19,7 +19,8 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { getRuntimeTallowHome } from "./config.js";
+import { getRuntimePathProvider } from "./config.js";
+import type { RuntimePathProvider } from "./runtime-path-provider.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -54,13 +55,17 @@ interface SessionPidFile {
 
 // ─── Runtime path helpers ───────────────────────────────────────────────────
 
+/** Runtime path provider used by PID manager lookups. */
+let pidManagerPathProvider: RuntimePathProvider = getRuntimePathProvider();
+
 /**
- * Resolve the runtime `run/` directory from the current home configuration.
+ * Override PID-manager runtime paths for tests.
  *
- * @returns Absolute path to the runtime directory
+ * @param provider - Optional provider override (reset when omitted)
+ * @returns Nothing
  */
-function getRunDirPath(): string {
-	return join(getRuntimeTallowHome(), "run");
+export function setPidManagerPathProviderForTests(provider?: RuntimePathProvider): void {
+	pidManagerPathProvider = provider ?? getRuntimePathProvider();
 }
 
 /**
@@ -69,7 +74,7 @@ function getRunDirPath(): string {
  * @returns Absolute path to run/pids.json
  */
 function getLegacyPidFilePath(): string {
-	return join(getRunDirPath(), "pids.json");
+	return pidManagerPathProvider.getLegacyPidFilePath();
 }
 
 /**
@@ -78,7 +83,7 @@ function getLegacyPidFilePath(): string {
  * @returns Absolute path to run/pids/
  */
 function getSessionPidDirPath(): string {
-	return join(getRunDirPath(), "pids");
+	return pidManagerPathProvider.getSessionPidDir();
 }
 
 // ─── Validation ──────────────────────────────────────────────────────────────

--- a/src/runtime-path-provider.ts
+++ b/src/runtime-path-provider.ts
@@ -1,0 +1,78 @@
+import { join } from "node:path";
+
+/** Runtime path provider for home-scoped tallow directories and files. */
+export interface RuntimePathProvider {
+	/** Resolve the active tallow home directory. */
+	getHomeDir(): string;
+	/** Resolve the run directory under home. */
+	getRunDir(): string;
+	/** Resolve the legacy global PID file path (run/pids.json). */
+	getLegacyPidFilePath(): string;
+	/** Resolve the session PID directory path (run/pids). */
+	getSessionPidDir(): string;
+	/** Resolve the trust directory path (trust). */
+	getTrustDir(): string;
+	/** Resolve the project trust store path (trust/projects.json). */
+	getProjectTrustStorePath(): string;
+}
+
+/** Callback used to resolve the active runtime home directory. */
+export type RuntimeHomeResolver = () => string;
+
+/**
+ * Resolve and validate runtime home values from a resolver callback.
+ *
+ * @param resolveHomeDir - Runtime home resolver callback
+ * @returns Non-empty home directory path
+ * @throws {Error} When resolver returns an empty value
+ */
+function requireHomeDir(resolveHomeDir: RuntimeHomeResolver): string {
+	const homeDir = resolveHomeDir();
+	if (!homeDir || homeDir.trim() === "") {
+		throw new Error("Runtime path provider requires a non-empty home directory");
+	}
+	return homeDir;
+}
+
+/**
+ * Create a runtime path provider backed by a home-directory resolver.
+ *
+ * @param resolveHomeDir - Callback resolving the current home directory
+ * @returns Runtime path provider
+ */
+export function createRuntimePathProvider(
+	resolveHomeDir: RuntimeHomeResolver
+): RuntimePathProvider {
+	return {
+		getHomeDir(): string {
+			return requireHomeDir(resolveHomeDir);
+		},
+		getRunDir(): string {
+			return join(requireHomeDir(resolveHomeDir), "run");
+		},
+		getLegacyPidFilePath(): string {
+			return join(requireHomeDir(resolveHomeDir), "run", "pids.json");
+		},
+		getSessionPidDir(): string {
+			return join(requireHomeDir(resolveHomeDir), "run", "pids");
+		},
+		getTrustDir(): string {
+			return join(requireHomeDir(resolveHomeDir), "trust");
+		},
+		getProjectTrustStorePath(): string {
+			return join(requireHomeDir(resolveHomeDir), "trust", "projects.json");
+		},
+	};
+}
+
+/**
+ * Create a runtime path provider pinned to a static home directory.
+ *
+ * Useful for tests that need deterministic path isolation.
+ *
+ * @param homeDir - Home directory path
+ * @returns Runtime path provider with fixed home root
+ */
+export function createStaticRuntimePathProvider(homeDir: string): RuntimePathProvider {
+	return createRuntimePathProvider(() => homeDir);
+}


### PR DESCRIPTION
## Summary
- add shared runtime path provider (`src/runtime-path-provider.ts`) with dynamic and static factories
- extend config with runtime path provider accessors and test override hook
- migrate pid-manager path resolution to provider-backed lookups with explicit test injection API
- migrate extension pid-registry to provider-backed path lookups with test injection API
- update pid manager and pid registry tests to use deterministic injected runtime paths
- add dedicated runtime path provider unit tests

## Testing
- bun test src/__tests__/pid-manager.test.ts src/__tests__/runtime-path-provider.test.ts extensions/_shared/__tests__/pid-registry.test.ts
- bun run typecheck
- bun run typecheck:extensions
- bun run lint