### PR TITLE
fix: stabilize claude-bridge skill path ordering

### DIFF
--- a/extensions/claude-bridge/index.ts
+++ b/extensions/claude-bridge/index.ts
@@ -135,7 +135,8 @@ export function getNonCollidingSkillPaths(
 		return paths;
 	}
 
-	for (const entry of entries) {
+	const sortedEntries = [...entries].sort((left, right) => left.name.localeCompare(right.name));
+	for (const entry of sortedEntries) {
 		if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
 		if (knownSkillNames.has(entry.name)) continue;
 


### PR DESCRIPTION
## Summary
- sort .claude/skills directory entries before building non-colliding skill paths
- make getNonCollidingSkillPaths deterministic across filesystems and CI runners
- prevent flaky ordering mismatches in claude-bridge unit tests

## Testing
- bun test extensions/claude-bridge/__tests__/claude-bridge.test.ts
- bun run typecheck:extensions
- bun run lint