### PR TITLE
feat(trust): box trust warning and add banner coverage

### DIFF
--- a/skills/tallow-expert/SKILL.md
+++ b/skills/tallow-expert/SKILL.md
@@ -33,7 +33,7 @@ Relay that answer to the user.
 
 | Component | Location |
 |-----------|----------|
-| Core source | `src/` (agent-runner.ts, atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, interactive-mode-patch.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, project-trust.ts, runtime-path-provider.ts, sdk.ts, session-migration.ts, session-utils.ts) |
+| Core source | `src/` (agent-runner.ts, atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, interactive-mode-patch.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, project-trust-banner.ts, project-trust.ts, runtime-path-provider.ts, sdk.ts, session-migration.ts, session-utils.ts) |
 | Extensions | `extensions/` — extension.json + index.ts each (50 bundled) |
 | Skills | `skills/` — subdirs with SKILL.md |
 | Agents | `agents/` — markdown with YAML frontmatter |

--- a/src/__tests__/project-trust-banner.test.ts
+++ b/src/__tests__/project-trust-banner.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { ProjectTrustContext } from "../project-trust.js";
+import {
+	buildProjectTrustBannerPayload,
+	formatMessageBox,
+	formatProjectTrustBanner,
+} from "../project-trust-banner.js";
+
+/**
+ * Creates a trust context for banner-format tests.
+ *
+ * @param status - Trust status to use in the context
+ * @returns Trust context fixture
+ */
+function makeTrustContext(status: ProjectTrustContext["status"]): ProjectTrustContext {
+	return {
+		canonicalCwd: "/tmp/project",
+		fingerprint: "fingerprint-123",
+		status,
+		storedFingerprint: status === "untrusted" ? null : "fingerprint-old",
+	};
+}
+
+describe("formatMessageBox", () => {
+	test("renders a box sized to the widest line", () => {
+		const box = formatMessageBox(["a", "bb"]);
+		expect(box.split("\n")).toEqual(["┌────┐", "│ a  │", "│ bb │", "└────┘"]);
+	});
+
+	test("renders a minimal box when no lines are provided", () => {
+		const box = formatMessageBox([]);
+		expect(box.split("\n")).toEqual(["┌──┐", "│  │", "└──┘"]);
+	});
+});
+
+describe("formatProjectTrustBanner", () => {
+	test("includes explicit untrusted risk language inside a box", () => {
+		const banner = formatProjectTrustBanner(makeTrustContext("untrusted"));
+
+		expect(banner).toContain("┌");
+		expect(banner).toContain("└");
+		expect(banner).toContain("PROJECT TRUST REQUIRED");
+		expect(banner).toContain("This project is currently untrusted.");
+		expect(banner).toContain("Trusting this folder means trusting the code and config inside it.");
+		expect(banner).toContain("Use /trust-project to enable these surfaces for this folder.");
+	});
+
+	test("uses stale-fingerprint language when trust is stale", () => {
+		const banner = formatProjectTrustBanner(makeTrustContext("stale_fingerprint"));
+
+		expect(banner).toContain("Trust is stale: trust-scoped config changed since last approval.");
+		expect(banner).not.toContain("This project is currently untrusted.");
+	});
+});
+
+describe("buildProjectTrustBannerPayload", () => {
+	test("returns matching content + details for notify and custom message paths", () => {
+		const trust = makeTrustContext("stale_fingerprint");
+		const payload = buildProjectTrustBannerPayload(trust);
+
+		expect(payload.content).toBe(formatProjectTrustBanner(trust));
+		expect(payload.details).toEqual({
+			canonicalCwd: trust.canonicalCwd,
+			fingerprint: trust.fingerprint,
+			status: trust.status,
+		});
+	});
+});

--- a/src/project-trust-banner.ts
+++ b/src/project-trust-banner.ts
@@ -1,0 +1,78 @@
+import type { ProjectTrustContext, ProjectTrustStatus } from "./project-trust.js";
+
+/** Structured payload for rendering trust warnings in UI + message stream. */
+export interface ProjectTrustBannerPayload {
+	readonly content: string;
+	readonly details: {
+		readonly canonicalCwd: string;
+		readonly fingerprint: string;
+		readonly status: ProjectTrustStatus;
+	};
+}
+
+/**
+ * Wrap multiline text in a simple box so high-signal warnings stand out in the UI.
+ *
+ * @param lines - Lines to render inside the box
+ * @returns Boxed message string
+ */
+export function formatMessageBox(lines: readonly string[]): string {
+	const safeLines = lines.length > 0 ? lines : [""];
+	const width = safeLines.reduce((max, line) => Math.max(max, line.length), 0);
+	const border = "─".repeat(width + 2);
+
+	return [
+		`┌${border}┐`,
+		...safeLines.map((line) => `│ ${line.padEnd(width, " ")} │`),
+		`└${border}┘`,
+	].join("\n");
+}
+
+/**
+ * Build a trust warning banner shown when repo-controlled surfaces are blocked.
+ *
+ * @param trust - Current project trust context
+ * @returns Human-readable trust warning message
+ */
+export function formatProjectTrustBanner(trust: ProjectTrustContext): string {
+	const statusLine =
+		trust.status === "stale_fingerprint"
+			? "Trust is stale: trust-scoped config changed since last approval."
+			: "This project is currently untrusted.";
+
+	return formatMessageBox([
+		"PROJECT TRUST REQUIRED",
+		"",
+		statusLine,
+		"",
+		"Blocked until trusted:",
+		"  plugins, hooks, mcpServers, packages, permissions, shellInterpolation,",
+		"  and project extensions.",
+		"",
+		"Trusting this folder means trusting the code and config inside it.",
+		"Those files can change agent behavior and execute commands.",
+		"",
+		"Use /trust-project to enable these surfaces for this folder.",
+		"Use /trust-status to inspect trust state or /untrust-project to revoke.",
+		"Trust auto-invalidates when trust-scoped project config changes.",
+	]);
+}
+
+/**
+ * Build a project-trust banner payload for both UI notifications and session messages.
+ *
+ * @param trust - Current project trust context
+ * @returns Payload with preformatted content and trust details
+ */
+export function buildProjectTrustBannerPayload(
+	trust: ProjectTrustContext
+): ProjectTrustBannerPayload {
+	return {
+		content: formatProjectTrustBanner(trust),
+		details: {
+			canonicalCwd: trust.canonicalCwd,
+			fingerprint: trust.fingerprint,
+			status: trust.status,
+		},
+	};
+}


### PR DESCRIPTION
## What

- wraps the project trust warning in a boxed banner for higher visibility in TUI notifications
- updates trust warning copy to explicitly state that trusting a folder means trusting code/config inside it
- extracts trust banner formatting/payload construction into `src/project-trust-banner.ts`
- adds unit tests for:
  - box formatting (including empty input)
  - untrusted vs stale trust messaging
  - parity payload used for notify/custom message paths

## Why

Runtime-injected behavior is intentional in tallow, but trust UX has to be explicit and hard to miss. This improves the warning clarity and adds regression coverage for the new warning surface.

## How

- `src/sdk.ts`
  - replaces inline banner creation with `buildProjectTrustBannerPayload(...)`
  - keeps both `ctx.ui.notify` and `project-trust-banner` message paths fed from the same payload
- `src/project-trust-banner.ts`
  - adds `formatMessageBox`, `formatProjectTrustBanner`, and `buildProjectTrustBannerPayload`
- `src/__tests__/project-trust-banner.test.ts`
  - new test suite covering copy + formatting + payload consistency

## Checklist

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] `bun test` passes
- [ ] `bun run build` succeeds

### Docs impact

If this PR adds/removes extensions, themes, agents, or commands:

- [ ] Extension/theme/agent counts updated in README.md, docs index, and overview
- [ ] New extension has a docs page in `docs/src/content/docs/extensions/`
- [ ] `node tests/docs-drift.mjs` passes

## Validation run locally

- ✅ `bun test src/__tests__/project-trust-banner.test.ts src/__tests__/project-trust.test.ts src/__tests__/sdk-plugin-specs.test.ts`
- ⚠️ `bun run typecheck` currently fails on baseline `main` with existing errors in `src/auth-hardening.ts` related to `AuthStorage` constructor visibility (not introduced by this PR)
