### PR TITLE
feat(lsp): add configurable startup timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **extensions:** lazy-initialize command expansion, context scanning, context fork indexing, and MCP startup connections behind first-use triggers
+- **lsp:** allow configuring language-server startup timeout via `lsp.startupTimeoutMs` with project-over-user precedence
 - **permissions:** add structured deny/ask reason metadata with redaction-safe messaging and shell-policy alignment
 - **subagent-tool:** compact completed background-agent histories with retained final output, bounded debug tails, and stale-record cleanup
 - **teams-tool:** enforce ring-buffer retention for team message logs with debug and limit env overrides

--- a/docs/src/content/docs/extensions/lsp.mdx
+++ b/docs/src/content/docs/extensions/lsp.mdx
@@ -13,3 +13,27 @@ can catch type errors and lint issues without you asking.
 
 Startup and request operations are time-bounded with automatic cleanup,
 so stalled language servers fail fast instead of hanging a tool call.
+
+## Configuration
+
+### `lsp.startupTimeoutMs`
+
+Controls how long tallow waits for a language server to start (process spawn,
+server readiness, and initial LSP handshake) before timing out and cleaning up.
+
+Default: `10000` ms.
+
+```json
+// .tallow/settings.json
+{
+  "lsp": {
+    "startupTimeoutMs": 15000
+  }
+}
+```
+
+Effective precedence:
+
+1. `.tallow/settings.json` (project)
+2. `~/.tallow/settings.json` (user)
+3. built-in default (`10000`)

--- a/extensions/lsp/__tests__/lsp-timeouts.test.ts
+++ b/extensions/lsp/__tests__/lsp-timeouts.test.ts
@@ -52,6 +52,50 @@ function writeFixture(rootDir: string, relativePath: string, content: string): s
 }
 
 /**
+ * Writes a JSON fixture file.
+ *
+ * @param filePath - Absolute path to write
+ * @param payload - JSON value to stringify
+ * @returns Nothing
+ */
+function writeJson(filePath: string, payload: unknown): void {
+	mkdirSync(dirname(filePath), { recursive: true });
+	writeFileSync(filePath, JSON.stringify(payload), "utf-8");
+}
+
+/**
+ * Captures timeout durations used by setTimeout while forcing immediate execution.
+ *
+ * @param action - Async action to run under the patched timer
+ * @returns Captured timeout durations in milliseconds
+ */
+async function captureTimeoutDelays(action: () => Promise<void>): Promise<number[]> {
+	const delays: number[] = [];
+	const originalSetTimeout = globalThis.setTimeout;
+
+	globalThis.setTimeout = ((
+		callback: Parameters<typeof setTimeout>[0],
+		delay?: Parameters<typeof setTimeout>[1],
+		...args: unknown[]
+	) => {
+		delays.push(typeof delay === "number" ? delay : 0);
+		return originalSetTimeout(() => {
+			if (typeof callback === "function") {
+				callback(...args);
+			}
+		}, 0);
+	}) as typeof setTimeout;
+
+	try {
+		await action();
+	} finally {
+		globalThis.setTimeout = originalSetTimeout;
+	}
+
+	return delays;
+}
+
+/**
  * Looks up a registered tool and throws when missing.
  *
  * @param harness - Extension harness instance
@@ -84,6 +128,8 @@ function getText(result: { content: Array<{ text?: string; type: string }> }): s
 describe("lsp timeout guards", () => {
 	let harness: ExtensionHarness;
 	let projectDir: string;
+	let agentDir: string;
+	let previousAgentDirEnv: string | undefined;
 
 	beforeAll(async () => {
 		runtime = setupLspMockRuntime();
@@ -104,7 +150,11 @@ describe("lsp timeout guards", () => {
 		resetLspStateForTests();
 		setLspProtocolBindingsForTests(runtime.protocol);
 		setLspSpawnForTests(runtime.spawn);
-		setLspTimeoutsForTests({ requestMs: 40, startupMs: 50 });
+		setLspTimeoutsForTests({ requestMs: 40 });
+
+		agentDir = mkdtempSync(join(tmpdir(), "tallow-lsp-agent-"));
+		previousAgentDirEnv = process.env.TALLOW_CODING_AGENT_DIR;
+		process.env.TALLOW_CODING_AGENT_DIR = agentDir;
 
 		projectDir = mkdtempSync(join(tmpdir(), "tallow-lsp-timeouts-"));
 		harness = ExtensionHarness.create();
@@ -122,6 +172,16 @@ describe("lsp timeout guards", () => {
 		} catch {
 			// Ignore state cleanup errors in tests
 		}
+		if (previousAgentDirEnv === undefined) {
+			delete process.env.TALLOW_CODING_AGENT_DIR;
+		} else {
+			process.env.TALLOW_CODING_AGENT_DIR = previousAgentDirEnv;
+		}
+		try {
+			rmSync(agentDir, { force: true, recursive: true });
+		} catch {
+			// Ignore temp-dir cleanup errors
+		}
 		try {
 			rmSync(projectDir, { force: true, recursive: true });
 		} catch {
@@ -129,9 +189,183 @@ describe("lsp timeout guards", () => {
 		}
 	});
 
-	test("returns a bounded startup-timeout error and cleans up process", async () => {
+	test("uses the default startup timeout when config is missing", async () => {
 		const previousInitialize = runtime.behavior.initialize;
 		runtime.behavior.initialize = async () => new Promise(() => {});
+
+		try {
+			const filePath = writeFixture(
+				projectDir,
+				"src/default-timeout.ts",
+				"export const value = 1;\n"
+			);
+			const lspSymbols = getTool(harness, "lsp_symbols");
+			const messages: Array<string | undefined> = [];
+			const ctx = createToolContext(projectDir, messages);
+			const signal = new AbortController().signal;
+			let result:
+				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
+				| undefined;
+
+			const delays = await captureTimeoutDelays(async () => {
+				result = await lspSymbols.execute(
+					"default-timeout",
+					{ file: filePath },
+					signal,
+					() => {},
+					ctx
+				);
+			});
+
+			expect(result?.isError).toBe(true);
+			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
+				"Language server startup timed out"
+			);
+			expect(delays).toContain(10_000);
+			expect(runtime.spawnedServers).toHaveLength(1);
+			expect(runtime.spawnedServers[0]?.killed).toBe(true);
+			expect(messages.at(-1)).toBeUndefined();
+		} finally {
+			runtime.behavior.initialize = previousInitialize;
+		}
+	});
+
+	test("project startup-timeout overrides user settings", async () => {
+		const previousInitialize = runtime.behavior.initialize;
+		runtime.behavior.initialize = async () => new Promise(() => {});
+
+		writeJson(join(agentDir, "settings.json"), { lsp: { startupTimeoutMs: 150 } });
+		writeJson(join(projectDir, ".tallow", "settings.json"), {
+			lsp: { startupTimeoutMs: 25 },
+		});
+
+		try {
+			const filePath = writeFixture(
+				projectDir,
+				"src/project-timeout.ts",
+				"export const value = 2;\n"
+			);
+			const lspSymbols = getTool(harness, "lsp_symbols");
+			const messages: Array<string | undefined> = [];
+			const ctx = createToolContext(projectDir, messages);
+			const signal = new AbortController().signal;
+			let result:
+				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
+				| undefined;
+
+			const delays = await captureTimeoutDelays(async () => {
+				result = await lspSymbols.execute(
+					"project-timeout",
+					{ file: filePath },
+					signal,
+					() => {},
+					ctx
+				);
+			});
+
+			expect(result?.isError).toBe(true);
+			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
+				"Language server startup timed out"
+			);
+			expect(delays).toContain(25);
+			expect(delays).not.toContain(150);
+		} finally {
+			runtime.behavior.initialize = previousInitialize;
+		}
+	});
+
+	test("uses user startup-timeout when project value is invalid", async () => {
+		const previousInitialize = runtime.behavior.initialize;
+		runtime.behavior.initialize = async () => new Promise(() => {});
+
+		writeJson(join(agentDir, "settings.json"), { lsp: { startupTimeoutMs: 80 } });
+		writeJson(join(projectDir, ".tallow", "settings.json"), {
+			lsp: { startupTimeoutMs: "fast" },
+		});
+
+		try {
+			const filePath = writeFixture(
+				projectDir,
+				"src/user-fallback-timeout.ts",
+				"export const value = 3;\n"
+			);
+			const lspSymbols = getTool(harness, "lsp_symbols");
+			const messages: Array<string | undefined> = [];
+			const ctx = createToolContext(projectDir, messages);
+			const signal = new AbortController().signal;
+			let result:
+				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
+				| undefined;
+
+			const delays = await captureTimeoutDelays(async () => {
+				result = await lspSymbols.execute(
+					"user-fallback-timeout",
+					{ file: filePath },
+					signal,
+					() => {},
+					ctx
+				);
+			});
+
+			expect(result?.isError).toBe(true);
+			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
+				"Language server startup timed out"
+			);
+			expect(delays).toContain(80);
+			expect(delays).not.toContain(10_000);
+		} finally {
+			runtime.behavior.initialize = previousInitialize;
+		}
+	});
+
+	test("falls back to default timeout when startup-timeout config is invalid", async () => {
+		const previousInitialize = runtime.behavior.initialize;
+		runtime.behavior.initialize = async () => new Promise(() => {});
+
+		writeJson(join(projectDir, ".tallow", "settings.json"), {
+			lsp: { startupTimeoutMs: "fast" },
+		});
+
+		try {
+			const filePath = writeFixture(
+				projectDir,
+				"src/invalid-timeout.ts",
+				"export const value = 3;\n"
+			);
+			const lspSymbols = getTool(harness, "lsp_symbols");
+			const messages: Array<string | undefined> = [];
+			const ctx = createToolContext(projectDir, messages);
+			const signal = new AbortController().signal;
+			let result:
+				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
+				| undefined;
+
+			const delays = await captureTimeoutDelays(async () => {
+				result = await lspSymbols.execute(
+					"invalid-timeout",
+					{ file: filePath },
+					signal,
+					() => {},
+					ctx
+				);
+			});
+
+			expect(result?.isError).toBe(true);
+			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
+				"Language server startup timed out"
+			);
+			expect(delays).toContain(10_000);
+		} finally {
+			runtime.behavior.initialize = previousInitialize;
+		}
+	});
+
+	test("startup-timeout failure kills server process and clears active state", async () => {
+		const previousInitialize = runtime.behavior.initialize;
+		runtime.behavior.initialize = async () => new Promise(() => {});
+		writeJson(join(projectDir, ".tallow", "settings.json"), {
+			lsp: { startupTimeoutMs: 50 },
+		});
 
 		try {
 			const filePath = writeFixture(projectDir, "src/example.ts", "export const value = 1;\n");

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -351,6 +351,18 @@
 			},
 			"additionalProperties": false
 		},
+		"lsp": {
+			"type": "object",
+			"description": "Language Server Protocol settings.",
+			"properties": {
+				"startupTimeoutMs": {
+					"type": "number",
+					"description": "Milliseconds to wait for language server startup before timing out.",
+					"minimum": 1
+				}
+			},
+			"additionalProperties": false
+		},
 		"disabledExtensions": {
 			"type": "array",
 			"items": { "type": "string" },


### PR DESCRIPTION
## Summary
- add lsp.startupTimeoutMs configuration
- resolve startup timeout precedence as project > user > default
- thread settings cwd from tool context to connection startup path
- add timeout-precedence and invalid-value coverage in LSP timeout tests
- document setting in LSP extension docs and changelog

## Validation
- bun test extensions/lsp/__tests__/lsp-timeouts.test.ts extensions/lsp/__tests__/lsp-tools.test.ts