### PR TITLE
feat(commands): add --worktree workflow to implement template

### DIFF
--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -1,10 +1,26 @@
 ---
 description: Full implementation workflow - scout gathers context, planner creates plan, worker implements
 ---
-Use the subagent tool with the centipede parameter to execute this workflow:
 
-1. First, use the "scout" agent to find all code relevant to: $@
-2. Then, use the "planner" agent to create an implementation plan for "$@" using the context from the previous step (use {previous} placeholder)
-3. Finally, use the "worker" agent to implement the plan from the previous step (use {previous} placeholder)
+Parse flags from `$@` before starting:
 
-Execute this as a centipede, passing output between steps via {previous}.
+- If `--worktree` is present:
+  1. Remove `--worktree` from the task text.
+  2. Generate a concise branch name from the task (`feat/<name>` or `fix/<name>`).
+  3. Create a new worktree from clean `HEAD`:
+     - Derive `<branch-slug>` from `<branch-name>` by replacing `/` with `-`.
+     - `git worktree add -b <branch-name> ../<repo-name>-<branch-slug> HEAD`
+  4. If the current checkout is dirty, ignore those changes completely.
+     - Do **not** stash, commit, or include them.
+     - Continue implementation only inside the new worktree.
+  5. If branch/path already exists, ask user whether to reuse, recreate, or abort.
+
+Then use the subagent tool with the `centipede` parameter:
+
+1. Use the `scout` agent to find all code relevant to the cleaned task text.
+2. Use the `planner` agent to create an implementation plan for that task using `{previous}`.
+3. Use the `worker` agent to implement the plan from `{previous}`.
+
+If `--worktree` was passed, set `cwd` for all centipede steps to the new worktree path.
+
+Execute as a centipede, passing outputs between steps via `{previous}`.


### PR DESCRIPTION
## Summary
- extend /implement template with --worktree flag handling
- create isolated worktree+branch from clean HEAD when --worktree is requested
- keep dirty current checkout untouched when using worktree mode
- pass the new worktree cwd through centipede steps

## Notes
- template-only change in templates/commands/implement.md