### PR TITLE
fix(slash-command-bridge): auto-continue after model-triggered compaction

### DIFF
--- a/extensions/slash-command-bridge/__tests__/slash-command-bridge.test.ts
+++ b/extensions/slash-command-bridge/__tests__/slash-command-bridge.test.ts
@@ -217,6 +217,70 @@ describe("compact", () => {
 		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
 	});
 
+	test("onComplete sends continuation message when agent is idle", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const toolCtx = buildContext({ compact: () => {} });
+		const agentEndCtx = buildContext({
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => true,
+		});
+
+		await executeTool({ command: "compact" }, toolCtx);
+		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
+
+		// Trigger onComplete and wait for the setTimeout(50) to fire
+		compactOptions?.onComplete?.();
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
+		expect(continuation).toBeDefined();
+		expect(continuation?.display).toBe(false);
+		expect(continuation?.options?.triggerTurn).toBe(true);
+		expect(continuation?.content).toContain("compaction is complete");
+	});
+
+	test("onComplete skips continuation when agent is not idle", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const toolCtx = buildContext({ compact: () => {} });
+		const agentEndCtx = buildContext({
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => false,
+		});
+
+		await executeTool({ command: "compact" }, toolCtx);
+		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
+
+		compactOptions?.onComplete?.();
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
+		expect(continuation).toBeUndefined();
+	});
+
+	test("onError does not send continuation message", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const toolCtx = buildContext({ compact: () => {} });
+		const agentEndCtx = buildContext({
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => true,
+		});
+
+		await executeTool({ command: "compact" }, toolCtx);
+		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
+
+		compactOptions?.onError?.();
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
+		expect(continuation).toBeUndefined();
+	});
+
 	test("agent_end hook is a no-op when no compact is pending", async () => {
 		let compactCalled = false;
 		const ctx = buildContext({

--- a/extensions/slash-command-bridge/index.ts
+++ b/extensions/slash-command-bridge/index.ts
@@ -244,6 +244,20 @@ WHEN NOT TO USE:
 	 * Fires compact after the agent finishes its turn. This avoids the
 	 * spinner-hang caused by aborting the agent mid-tool-execution.
 	 * The tool sets `pendingCompact`, then agent_end picks it up.
+	 *
+	 * After compaction completes, checks whether the agent is idle. When the
+	 * model triggered compaction (vs. the user typing during it), the
+	 * framework's `flushCompactionQueue` finds no queued messages and the
+	 * agent sits at the input prompt — even though the model promised to
+	 * continue. We fix this by sending a hidden continuation message via
+	 * `pi.sendMessage()` with `triggerTurn: true` to re-prompt the agent.
+	 *
+	 * A short `setTimeout` allows `flushCompactionQueue`'s fire-and-forget
+	 * async path to settle first, so we don't conflict with user-queued
+	 * messages that already restarted the agent.
+	 *
+	 * @see Plan 98 — deferred compact to agent_end (introduced idle-after-compact)
+	 * @see Plan 157 — auto-continue after model-triggered compaction
 	 */
 	pi.on("agent_end", (_event, ctx) => {
 		if (!pendingCompact) return;
@@ -261,14 +275,30 @@ WHEN NOT TO USE:
 			onComplete: () => {
 				ctx.ui?.setWorkingMessage?.();
 				ctx.ui?.setStatus?.("compact", undefined);
-				// Framework's executeCompaction rebuilds the UI and
-				// shows the compaction summary. No extra action needed.
+
+				// After compaction, re-prompt the agent if no user messages
+				// triggered a turn via flushCompactionQueue. The setTimeout
+				// lets flushCompactionQueue's async work settle first.
+				setTimeout(() => {
+					if (ctx.isIdle()) {
+						pi.sendMessage(
+							{
+								customType: "compact-continue",
+								content:
+									"Session compaction is complete. Continue with the task " +
+									"you were working on before compaction was triggered.",
+								display: false,
+							},
+							{ triggerTurn: true }
+						);
+					}
+				}, 50);
 			},
 			onError: () => {
 				ctx.ui?.setWorkingMessage?.();
 				ctx.ui?.setStatus?.("compact", undefined);
 				// Framework's executeCompaction handles error/cancel
-				// display. No extra handling needed.
+				// display. No continuation on failure — user decides.
 			},
 		});
 	});


### PR DESCRIPTION
## Summary
- Fix model-triggered compaction leaving the agent idle instead of resuming work
- After `onComplete`, check `ctx.isIdle()` and send a hidden continuation message to re-prompt the agent

## Changes Made
- **`extensions/slash-command-bridge/index.ts`** — Added continuation logic in `onComplete` callback: 50ms settle delay → `ctx.isIdle()` check → `pi.sendMessage()` with `triggerTurn: true` and `display: false`
- **`extensions/slash-command-bridge/__tests__/slash-command-bridge.test.ts`** — 3 new tests: continuation when idle, no continuation when not idle, no continuation on error

## Testing
- 26/26 tests pass (3 new)
- Typecheck clean (core + extensions)
- Lint clean

Closes plan 157.