### PR TITLE
fix(tasks): distinguish "agents" from "teammates" in footer bar

### DIFF
--- a/extensions/tasks/commands/register-tasks-extension.ts
+++ b/extensions/tasks/commands/register-tasks-extension.ts
@@ -565,10 +565,11 @@ export function registerTasksExtension(
 
 		const totalCount = allAgents.length + teamMates.length;
 		const coloredNames = [...agentNames].map((name) => formatWidgetIdentity(name)).join(" ");
+		const label = teamMates.length > 0 ? "teammate" : "agent";
 
 		ctx.ui.setStatus(
 			"agents",
-			`${coloredNames} ${formatWidgetRole(ctx, "meta", "·")} ${formatWidgetRole(ctx, "hint", `${totalCount} teammate${totalCount > 1 ? "s" : ""}`)}`
+			`${coloredNames} ${formatWidgetRole(ctx, "meta", "·")} ${formatWidgetRole(ctx, "hint", `${totalCount} ${label}${totalCount > 1 ? "s" : ""}`)}`
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Footer agent bar now says "N agents" for subagents and "N teammates" only when a `team_*` team is active
- Fixes misleading UI where "teammates" implied Ctrl+X would show them in the Team Dashboard

## Changes Made

- `extensions/tasks/commands/register-tasks-extension.ts`: use "agent" label when only subagents are running, "teammate" when team teammates are present

## Testing

- Build passes
- Label logic is a single ternary on `teamMates.length > 0`