### PR TITLE
refactor(lsp): extract shared helpers to reduce code duplication

### DIFF
--- a/extensions/__integration__/shell-policy-confirm.test.ts
+++ b/extensions/__integration__/shell-policy-confirm.test.ts
@@ -86,6 +86,24 @@ function createPolicyExtension(confirmBehavior: "accept" | "deny" | "throw"): Ex
 }
 
 /**
+ * Creates a result-tracking extension that records bash tool_result text.
+ *
+ * @returns Tuple of [collected results array, extension factory]
+ */
+function createResultTracker(): [string[], ExtensionFactory] {
+	const toolResults: string[] = [];
+	const factory: ExtensionFactory = (pi: ExtensionAPI): void => {
+		pi.on("tool_result", async (event) => {
+			if (event.toolName === "bash") {
+				const text = event.content.find((c) => c.type === "text");
+				if (text?.type === "text") toolResults.push(text.text);
+			}
+		});
+	};
+	return [toolResults, factory];
+}
+
+/**
  * Scripted model response that calls bash with the given command, followed
  * by a text response so the agent loop completes cleanly.
  *
@@ -105,16 +123,7 @@ function bashCallThenDone(command: string) {
 
 describe("Shell Policy Confirm — confirmed high-risk", () => {
 	it("allows execution when user confirms", async () => {
-		const toolResults: string[] = [];
-
-		const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "bash") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
-		};
+		const [toolResults, resultTracker] = createResultTracker();
 
 		runner = await createSessionRunner({
 			streamFn: bashCallThenDone("sudo ls /etc"),
@@ -140,16 +149,7 @@ describe("Shell Policy Confirm — confirmed high-risk", () => {
 
 describe("Shell Policy Confirm — denied high-risk", () => {
 	it("blocks execution when user denies", async () => {
-		const toolResults: string[] = [];
-
-		const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "bash") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
-		};
+		const [toolResults, resultTracker] = createResultTracker();
 
 		runner = await createSessionRunner({
 			streamFn: bashCallThenDone("sudo rm -rf /tmp/test"),
@@ -191,15 +191,7 @@ describe("Shell Policy Confirm — permission-rule denial messaging", () => {
 			process.env.TALLOW_PROJECT_TRUST_STATUS = "trusted";
 			resetPermissionCache();
 
-			const toolResults: string[] = [];
-			const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-				pi.on("tool_result", async (event) => {
-					if (event.toolName === "bash") {
-						const text = event.content.find((c) => c.type === "text");
-						if (text?.type === "text") toolResults.push(text.text);
-					}
-				});
-			};
+			const [toolResults, resultTracker] = createResultTracker();
 
 			const permissionAwarePolicy: ExtensionFactory = (pi: ExtensionAPI): void => {
 				registerSafeBashTool(pi);
@@ -246,16 +238,7 @@ describe("Shell Policy Confirm — permission-rule denial messaging", () => {
 
 describe("Shell Policy Confirm — interrupted confirmation", () => {
 	it("blocks execution when confirmation throws", async () => {
-		const toolResults: string[] = [];
-
-		const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "bash") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
-		};
+		const [toolResults, resultTracker] = createResultTracker();
 
 		runner = await createSessionRunner({
 			streamFn: bashCallThenDone("sudo apt-get install foo"),
@@ -301,15 +284,7 @@ describe("Shell Policy Confirm — denylist bypass", () => {
 			});
 		};
 
-		const toolResults: string[] = [];
-		const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "bash") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
-		};
+		const [toolResults, resultTracker] = createResultTracker();
 
 		// Fork bomb — always denied, never reaches confirmation
 		const forkBomb = ":(){ :|:& };:";
@@ -373,15 +348,7 @@ describe("Shell Policy Confirm — handler ordering", () => {
 			});
 		};
 
-		const toolResults: string[] = [];
-		const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "bash") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
-		};
+		const [toolResults, resultTracker] = createResultTracker();
 
 		runner = await createSessionRunner({
 			streamFn: bashCallThenDone("sudo cat /etc/shadow"),
@@ -426,15 +393,7 @@ describe("Shell Policy Confirm — handler ordering", () => {
 			});
 		};
 
-		const toolResults: string[] = [];
-		const resultTracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "bash") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
-		};
+		const [toolResults, resultTracker] = createResultTracker();
 
 		runner = await createSessionRunner({
 			streamFn: bashCallThenDone("sudo cat /etc/shadow"),

--- a/extensions/context-files/__tests__/nested-rules.test.ts
+++ b/extensions/context-files/__tests__/nested-rules.test.ts
@@ -69,6 +69,23 @@ function buildCommandCtx() {
 }
 
 /**
+ * Fires session_start + before_agent_start and returns the injected systemPrompt
+ * (or undefined when no extension contributed one).
+ *
+ * @returns The systemPrompt string if an extension contributed one, else undefined
+ */
+async function initAndGetPrompt(): Promise<string | undefined> {
+	const ctx = buildEventCtx();
+	await harness.fireEvent("session_start", { type: "session_start" }, ctx);
+	const [result] = await harness.fireEvent(
+		"before_agent_start",
+		{ type: "before_agent_start", systemPrompt: "SYSTEM" },
+		ctx
+	);
+	return (result as { systemPrompt: string } | undefined)?.systemPrompt;
+}
+
+/**
  * Retrieve a command handler from the harness, failing the test if not found.
  *
  * @param name - Command name
@@ -108,42 +125,26 @@ describe("nested rules discovery", () => {
 	test("discovers .tallow/rules/*.md in a subdirectory", async () => {
 		const rulesDir = join(cwdDir, "packages", "api", ".tallow", "rules");
 		mkdirSync(rulesDir, { recursive: true });
-		const rulePath = join(rulesDir, "api-rules.md");
-		writeFileSync(rulePath, "Subdir tallow rule");
+		writeFileSync(join(rulesDir, "api-rules.md"), "Subdir tallow rule");
 
-		const ctx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
-		const [result] = await harness.fireEvent(
-			"before_agent_start",
-			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			ctx
-		);
+		const prompt = await initAndGetPrompt();
 
-		expect(result).toBeDefined();
-		const { systemPrompt } = result as { systemPrompt: string };
-		expect(systemPrompt).toContain("Additional Project Context");
-		expect(systemPrompt).toContain("Subdir tallow rule");
-		expect(systemPrompt).toContain("api-rules.md");
+		expect(prompt).toBeDefined();
+		expect(prompt).toContain("Additional Project Context");
+		expect(prompt).toContain("Subdir tallow rule");
+		expect(prompt).toContain("api-rules.md");
 	});
 
 	test("discovers .claude/rules/*.md in a subdirectory", async () => {
 		const rulesDir = join(cwdDir, "apps", "web", ".claude", "rules");
 		mkdirSync(rulesDir, { recursive: true });
-		const rulePath = join(rulesDir, "web-rules.md");
-		writeFileSync(rulePath, "Subdir claude rule");
+		writeFileSync(join(rulesDir, "web-rules.md"), "Subdir claude rule");
 
-		const ctx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
-		const [result] = await harness.fireEvent(
-			"before_agent_start",
-			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			ctx
-		);
+		const prompt = await initAndGetPrompt();
 
-		expect(result).toBeDefined();
-		const { systemPrompt } = result as { systemPrompt: string };
-		expect(systemPrompt).toContain("Subdir claude rule");
-		expect(systemPrompt).toContain("web-rules.md");
+		expect(prompt).toBeDefined();
+		expect(prompt).toContain("Subdir claude rule");
+		expect(prompt).toContain("web-rules.md");
 	});
 
 	test("discovers rules at multiple nesting levels", async () => {
@@ -155,18 +156,11 @@ describe("nested rules discovery", () => {
 		writeFileSync(join(level1Rules, "level1.md"), "Level 1 rules");
 		writeFileSync(join(level2Rules, "level2.md"), "Level 2 rules");
 
-		const ctx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
-		const [result] = await harness.fireEvent(
-			"before_agent_start",
-			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			ctx
-		);
+		const prompt = await initAndGetPrompt();
 
-		expect(result).toBeDefined();
-		const { systemPrompt } = result as { systemPrompt: string };
-		expect(systemPrompt).toContain("Level 1 rules");
-		expect(systemPrompt).toContain("Level 2 rules");
+		expect(prompt).toBeDefined();
+		expect(prompt).toContain("Level 1 rules");
+		expect(prompt).toContain("Level 2 rules");
 	});
 
 	test("skips node_modules/.tallow/rules/ (SKIP_DIRS)", async () => {
@@ -174,15 +168,8 @@ describe("nested rules discovery", () => {
 		mkdirSync(rulesDir, { recursive: true });
 		writeFileSync(join(rulesDir, "lib-rules.md"), "Should be skipped");
 
-		const ctx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
-		const [result] = await harness.fireEvent(
-			"before_agent_start",
-			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			ctx
-		);
-
-		expect(result).toBeUndefined();
+		const prompt = await initAndGetPrompt();
+		expect(prompt).toBeUndefined();
 	});
 
 	test("skips .hidden-dir/.tallow/rules/ (dot-prefix filter)", async () => {
@@ -190,30 +177,16 @@ describe("nested rules discovery", () => {
 		mkdirSync(rulesDir, { recursive: true });
 		writeFileSync(join(rulesDir, "hidden-rules.md"), "Hidden rules");
 
-		const ctx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
-		const [result] = await harness.fireEvent(
-			"before_agent_start",
-			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			ctx
-		);
-
-		expect(result).toBeUndefined();
+		const prompt = await initAndGetPrompt();
+		expect(prompt).toBeUndefined();
 	});
 
 	test("empty rules dirs don't produce entries", async () => {
 		const rulesDir = join(cwdDir, "pkg", ".tallow", "rules");
 		mkdirSync(rulesDir, { recursive: true });
 
-		const ctx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
-		const [result] = await harness.fireEvent(
-			"before_agent_start",
-			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			ctx
-		);
-
-		expect(result).toBeUndefined();
+		const prompt = await initAndGetPrompt();
+		expect(prompt).toBeUndefined();
 	});
 
 	test("works with /add-dir for additional directories", async () => {
@@ -221,11 +194,10 @@ describe("nested rules discovery", () => {
 		mkdirSync(rulesDir, { recursive: true });
 		writeFileSync(join(rulesDir, "user-rules.md"), "Additional dir nested rule");
 
-		// Initialize session with cwd set to the main project directory
-		const eventCtx = buildEventCtx();
-		await harness.fireEvent("session_start", { type: "session_start" }, eventCtx);
+		// Initialize session, then add the additional directory
+		const ctx = buildEventCtx();
+		await harness.fireEvent("session_start", { type: "session_start" }, ctx);
 
-		// Add the additional directory and ensure nested rules are discovered
 		const cmdCtx = buildCommandCtx();
 		await getCmd("add-dir").handler(additionalDir, cmdCtx);
 		expect(
@@ -237,11 +209,11 @@ describe("nested rules discovery", () => {
 		const [result] = await harness.fireEvent(
 			"before_agent_start",
 			{ type: "before_agent_start", systemPrompt: "SYSTEM" },
-			eventCtx
+			ctx
 		);
-
 		expect(result).toBeDefined();
-		const { systemPrompt } = result as { systemPrompt: string };
-		expect(systemPrompt).toContain("Additional dir nested rule");
+		expect((result as { systemPrompt: string }).systemPrompt).toContain(
+			"Additional dir nested rule"
+		);
 	});
 });

--- a/extensions/lsp/__tests__/lsp-timeouts.test.ts
+++ b/extensions/lsp/__tests__/lsp-timeouts.test.ts
@@ -125,6 +125,9 @@ function getText(result: { content: Array<{ text?: string; type: string }> }): s
 	throw new Error("Expected a text block in tool result");
 }
 
+/** Tool result with optional error flag. */
+type ToolResult = { content: Array<{ text?: string; type: string }>; isError?: boolean };
+
 describe("lsp timeout guards", () => {
 	let harness: ExtensionHarness;
 	let projectDir: string;
@@ -189,27 +192,32 @@ describe("lsp timeout guards", () => {
 		}
 	});
 
-	test("uses the default startup timeout when config is missing", async () => {
+	/**
+	 * Runs lsp_symbols against a fixture file with initialize hanging forever,
+	 * captures setTimeout delays, and returns the result.
+	 *
+	 * @param fixtureName - Relative path under projectDir for the fixture file
+	 * @param fixtureContent - Content to write into the fixture
+	 * @returns Captured timeout delays, tool result, and working-message log
+	 */
+	async function runWithHangingInit(
+		fixtureName: string,
+		fixtureContent = "export const value = 1;\n"
+	): Promise<{ delays: number[]; result: ToolResult; messages: Array<string | undefined> }> {
 		const previousInitialize = runtime.behavior.initialize;
 		runtime.behavior.initialize = async () => new Promise(() => {});
 
 		try {
-			const filePath = writeFixture(
-				projectDir,
-				"src/default-timeout.ts",
-				"export const value = 1;\n"
-			);
+			const filePath = writeFixture(projectDir, fixtureName, fixtureContent);
 			const lspSymbols = getTool(harness, "lsp_symbols");
 			const messages: Array<string | undefined> = [];
 			const ctx = createToolContext(projectDir, messages);
 			const signal = new AbortController().signal;
-			let result:
-				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
-				| undefined;
+			let result: ToolResult = { content: [] };
 
 			const delays = await captureTimeoutDelays(async () => {
 				result = await lspSymbols.execute(
-					"default-timeout",
+					fixtureName.replace(/\//g, "-"),
 					{ file: filePath },
 					signal,
 					() => {},
@@ -217,147 +225,61 @@ describe("lsp timeout guards", () => {
 				);
 			});
 
-			expect(result?.isError).toBe(true);
-			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
-				"Language server startup timed out"
-			);
-			expect(delays).toContain(10_000);
-			expect(runtime.spawnedServers).toHaveLength(1);
-			expect(runtime.spawnedServers[0]?.killed).toBe(true);
-			expect(messages.at(-1)).toBeUndefined();
+			return { delays, result, messages };
 		} finally {
 			runtime.behavior.initialize = previousInitialize;
 		}
+	}
+
+	test("uses the default startup timeout when config is missing", async () => {
+		const { delays, result, messages } = await runWithHangingInit("src/default-timeout.ts");
+
+		expect(result.isError).toBe(true);
+		expect(getText(result)).toContain("Language server startup timed out");
+		expect(delays).toContain(10_000);
+		expect(runtime.spawnedServers).toHaveLength(1);
+		expect(runtime.spawnedServers[0]?.killed).toBe(true);
+		expect(messages.at(-1)).toBeUndefined();
 	});
 
 	test("project startup-timeout overrides user settings", async () => {
-		const previousInitialize = runtime.behavior.initialize;
-		runtime.behavior.initialize = async () => new Promise(() => {});
-
 		writeJson(join(agentDir, "settings.json"), { lsp: { startupTimeoutMs: 150 } });
 		writeJson(join(projectDir, ".tallow", "settings.json"), {
 			lsp: { startupTimeoutMs: 25 },
 		});
 
-		try {
-			const filePath = writeFixture(
-				projectDir,
-				"src/project-timeout.ts",
-				"export const value = 2;\n"
-			);
-			const lspSymbols = getTool(harness, "lsp_symbols");
-			const messages: Array<string | undefined> = [];
-			const ctx = createToolContext(projectDir, messages);
-			const signal = new AbortController().signal;
-			let result:
-				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
-				| undefined;
+		const { delays, result } = await runWithHangingInit("src/project-timeout.ts");
 
-			const delays = await captureTimeoutDelays(async () => {
-				result = await lspSymbols.execute(
-					"project-timeout",
-					{ file: filePath },
-					signal,
-					() => {},
-					ctx
-				);
-			});
-
-			expect(result?.isError).toBe(true);
-			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
-				"Language server startup timed out"
-			);
-			expect(delays).toContain(25);
-			expect(delays).not.toContain(150);
-		} finally {
-			runtime.behavior.initialize = previousInitialize;
-		}
+		expect(result.isError).toBe(true);
+		expect(getText(result)).toContain("Language server startup timed out");
+		expect(delays).toContain(25);
+		expect(delays).not.toContain(150);
 	});
 
 	test("uses user startup-timeout when project value is invalid", async () => {
-		const previousInitialize = runtime.behavior.initialize;
-		runtime.behavior.initialize = async () => new Promise(() => {});
-
 		writeJson(join(agentDir, "settings.json"), { lsp: { startupTimeoutMs: 80 } });
 		writeJson(join(projectDir, ".tallow", "settings.json"), {
 			lsp: { startupTimeoutMs: "fast" },
 		});
 
-		try {
-			const filePath = writeFixture(
-				projectDir,
-				"src/user-fallback-timeout.ts",
-				"export const value = 3;\n"
-			);
-			const lspSymbols = getTool(harness, "lsp_symbols");
-			const messages: Array<string | undefined> = [];
-			const ctx = createToolContext(projectDir, messages);
-			const signal = new AbortController().signal;
-			let result:
-				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
-				| undefined;
+		const { delays, result } = await runWithHangingInit("src/user-fallback-timeout.ts");
 
-			const delays = await captureTimeoutDelays(async () => {
-				result = await lspSymbols.execute(
-					"user-fallback-timeout",
-					{ file: filePath },
-					signal,
-					() => {},
-					ctx
-				);
-			});
-
-			expect(result?.isError).toBe(true);
-			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
-				"Language server startup timed out"
-			);
-			expect(delays).toContain(80);
-			expect(delays).not.toContain(10_000);
-		} finally {
-			runtime.behavior.initialize = previousInitialize;
-		}
+		expect(result.isError).toBe(true);
+		expect(getText(result)).toContain("Language server startup timed out");
+		expect(delays).toContain(80);
+		expect(delays).not.toContain(10_000);
 	});
 
 	test("falls back to default timeout when startup-timeout config is invalid", async () => {
-		const previousInitialize = runtime.behavior.initialize;
-		runtime.behavior.initialize = async () => new Promise(() => {});
-
 		writeJson(join(projectDir, ".tallow", "settings.json"), {
 			lsp: { startupTimeoutMs: "fast" },
 		});
 
-		try {
-			const filePath = writeFixture(
-				projectDir,
-				"src/invalid-timeout.ts",
-				"export const value = 3;\n"
-			);
-			const lspSymbols = getTool(harness, "lsp_symbols");
-			const messages: Array<string | undefined> = [];
-			const ctx = createToolContext(projectDir, messages);
-			const signal = new AbortController().signal;
-			let result:
-				| { content: Array<{ text?: string; type: string }>; isError?: boolean }
-				| undefined;
+		const { delays, result } = await runWithHangingInit("src/invalid-timeout.ts");
 
-			const delays = await captureTimeoutDelays(async () => {
-				result = await lspSymbols.execute(
-					"invalid-timeout",
-					{ file: filePath },
-					signal,
-					() => {},
-					ctx
-				);
-			});
-
-			expect(result?.isError).toBe(true);
-			expect(getText(result as { content: Array<{ text?: string; type: string }> })).toContain(
-				"Language server startup timed out"
-			);
-			expect(delays).toContain(10_000);
-		} finally {
-			runtime.behavior.initialize = previousInitialize;
-		}
+		expect(result.isError).toBe(true);
+		expect(getText(result)).toContain("Language server startup timed out");
+		expect(delays).toContain(10_000);
 	});
 
 	test("startup-timeout failure kills server process and clears active state", async () => {
@@ -456,7 +378,7 @@ describe("lsp timeout guards", () => {
 		);
 
 		expect(timeoutResult.isError).toBe(true);
-		expect(getText(timeoutResult)).toContain("Document symbols request timed out");
+		expect(getText(timeoutResult)).toContain("document symbols request timed out");
 		expect(runtime.spawnedServers).toHaveLength(1);
 		expect(runtime.spawnedServers[0]?.killed).toBe(true);
 

--- a/extensions/lsp/__tests__/lsp-tools.test.ts
+++ b/extensions/lsp/__tests__/lsp-tools.test.ts
@@ -226,7 +226,7 @@ describe("lsp tool behavior with timeout guards", () => {
 		);
 
 		expect(timeoutResult.isError).toBe(true);
-		expect(firstText(timeoutResult)).toContain("Workspace symbols request timed out");
+		expect(firstText(timeoutResult)).toContain("workspace symbols request timed out");
 		expect(runtime.spawnedServers).toHaveLength(1);
 		expect(runtime.spawnedServers[0]?.killed).toBe(true);
 

--- a/extensions/lsp/index.ts
+++ b/extensions/lsp/index.ts
@@ -957,6 +957,132 @@ async function sendRequestWithTimeout(
 	);
 }
 
+/** Successful file-based LSP connection setup. */
+interface FileSetup {
+	conn: LSPConnection;
+	filePath: string;
+}
+
+/**
+ * Resolves a file path, detects language, creates/retrieves an LSP connection,
+ * validates capability support, and opens the document — the common preamble
+ * shared by all file-based LSP tools.
+ *
+ * @param params - Tool parameters containing the file path
+ * @param signal - Optional cancellation signal
+ * @param ctx - Extension context with cwd and UI
+ * @param capability - Required server capability key
+ * @param capabilityLabel - Human-readable capability name for error messages
+ * @returns Either a ready FileSetup (has `conn`) or an early-exit tool result
+ */
+async function withFileConnection(
+	params: { file: string },
+	signal: AbortSignal | undefined,
+	ctx: { cwd: string; ui: { setWorkingMessage(msg?: string): void } },
+	capability: keyof LSPConnection["capabilities"],
+	capabilityLabel: string
+): Promise<
+	FileSetup | { details: object; content: { type: "text"; text: string }[]; isError?: boolean }
+> {
+	const filePath = path.isAbsolute(params.file) ? params.file : path.resolve(ctx.cwd, params.file);
+	const language = getLanguageForFile(filePath);
+
+	if (!language) {
+		return {
+			details: {},
+			content: [{ type: "text", text: `Unsupported file type: ${params.file}` }],
+		};
+	}
+
+	let conn: LSPConnection | null = null;
+	try {
+		conn = await getOrCreateConnectionForFile(language, filePath, {
+			onStarting: (lang) => ctx.ui.setWorkingMessage(`Starting ${lang} language server`),
+			settingsCwd: ctx.cwd,
+			signal,
+		});
+	} catch (error) {
+		if (isAbortError(error)) throw error;
+		if (isTimeoutError(error)) {
+			return {
+				details: {},
+				content: [{ type: "text", text: `Language server startup timed out for ${language}` }],
+				isError: true,
+			};
+		}
+		return {
+			details: {},
+			content: [{ type: "text", text: `Error starting language server: ${error}` }],
+			isError: true,
+		};
+	} finally {
+		ctx.ui.setWorkingMessage();
+	}
+
+	if (!conn) {
+		return {
+			details: {},
+			content: [
+				{
+					type: "text",
+					text: `Language server not available for ${language}. Install: ${SERVER_CONFIGS[language]?.command ?? language}`,
+				},
+			],
+		};
+	}
+
+	if (!conn.capabilities[capability]) {
+		return {
+			details: {},
+			content: [{ type: "text", text: `${capabilityLabel} not supported by this language server` }],
+		};
+	}
+
+	await openDocument(conn, filePath);
+	return { conn, filePath };
+}
+
+/**
+ * Sends an LSP request with timeout/abort handling and formats the response.
+ *
+ * @param conn - Active LSP connection
+ * @param requestType - LSP request type descriptor
+ * @param params - Request parameters
+ * @param signal - Optional cancellation signal
+ * @param description - Human-readable label for error messages
+ * @param formatResult - Callback to convert the raw response into display text
+ * @returns Formatted tool result or error
+ */
+async function sendAndFormat<T>(
+	conn: LSPConnection,
+	requestType: { method: string },
+	params: unknown,
+	signal: AbortSignal | undefined,
+	description: string,
+	formatResult: (result: T) => string
+): Promise<{ details: object; content: { type: "text"; text: string }[]; isError?: boolean }> {
+	try {
+		const result = (await sendRequestWithTimeout(
+			conn,
+			requestType,
+			params,
+			signal,
+			description
+		)) as T;
+		return { details: {}, content: [{ type: "text", text: formatResult(result) }] };
+	} catch (error) {
+		if (isAbortError(error)) throw error;
+		if (isTimeoutError(error)) {
+			return {
+				details: {},
+				content: [{ type: "text", text: `${description} timed out` }],
+				isError: true,
+			};
+		}
+		return { details: {}, content: [{ type: "text", text: `Error: ${error}` }], isError: true };
+	}
+}
+
 /**
  * Registers LSP tools for definition, references, hover, and symbol search.
  * @param pi - Extension API for registering tools and event handlers
@@ -980,113 +1106,27 @@ SUPPORTED: TypeScript, Python (ty/pyright), Rust, Swift, PHP (intelephense)`,
 			character: Type.Number({ description: "Character/column position (1-indexed)" }),
 		}),
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file)
-				? params.file
-				: path.resolve(ctx.cwd, params.file);
-			const language = getLanguageForFile(filePath);
+			const setup = await withFileConnection(
+				params,
+				signal,
+				ctx,
+				"definitionProvider",
+				"Definition provider"
+			);
+			if (!("conn" in setup)) return setup;
 
-			if (!language) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Unsupported file type: ${params.file}` }],
-				};
-			}
-
-			let conn: LSPConnection | null = null;
-			try {
-				conn = await getOrCreateConnectionForFile(language, filePath, {
-					onStarting: (lang) => ctx.ui.setWorkingMessage(`Starting ${lang} language server`),
-					settingsCwd: ctx.cwd,
-					signal,
-				});
-			} catch (error) {
-				if (isAbortError(error)) {
-					// Propagate cancellation so the tool runner can stop cleanly
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						details: {},
-						content: [
-							{
-								type: "text",
-								text: `Language server startup timed out for ${language}`,
-							},
-						],
-						isError: true,
-					};
-				}
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Error starting language server: ${error}`,
-						},
-					],
-					isError: true,
-				};
-			} finally {
-				// Always clear working message, even on error or cancellation
-				ctx.ui.setWorkingMessage();
-			}
-
-			if (!conn) {
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Language server not available for ${language}. Install: ${SERVER_CONFIGS[language].command}`,
-						},
-					],
-				};
-			}
-
-			if (!conn.capabilities.definitionProvider) {
-				return {
-					details: {},
-					content: [
-						{ type: "text", text: "Definition provider not supported by this language server" },
-					],
-				};
-			}
-
-			await openDocument(conn, filePath);
-
-			try {
-				const result = (await sendRequestWithTimeout(
-					conn,
-					protocolBindings.DefinitionRequest.type,
-					{
-						textDocument: { uri: filePathToUri(filePath) },
-						position: { line: params.line - 1, character: params.character - 1 },
-					},
-					signal,
-					"LSP definition request"
-				)) as Location | Location[] | LocationLink | LocationLink[] | null;
-
-				return {
-					details: {},
-					content: [{ type: "text", text: formatLocations(result) }],
-				};
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						content: [{ type: "text", text: "Definition request timed out" }],
-						details: {},
-						isError: true,
-					};
-				}
-				return {
-					content: [{ type: "text", text: `Error: ${error}` }],
-					details: {},
-					isError: true,
-				};
-			}
+			return sendAndFormat(
+				setup.conn,
+				protocolBindings.DefinitionRequest.type,
+				{
+					textDocument: { uri: filePathToUri(setup.filePath) },
+					position: { line: params.line - 1, character: params.character - 1 },
+				},
+				signal,
+				"LSP definition request",
+				(result: Location | Location[] | LocationLink | LocationLink[] | null) =>
+					formatLocations(result)
+			);
 		},
 	});
 
@@ -1109,111 +1149,30 @@ WHEN TO USE:
 			),
 		}),
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file)
-				? params.file
-				: path.resolve(ctx.cwd, params.file);
-			const language = getLanguageForFile(filePath);
+			const setup = await withFileConnection(
+				params,
+				signal,
+				ctx,
+				"referencesProvider",
+				"References provider"
+			);
+			if (!("conn" in setup)) return setup;
 
-			if (!language) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Unsupported file type: ${params.file}` }],
-				};
-			}
-
-			let conn: LSPConnection | null = null;
-			try {
-				conn = await getOrCreateConnectionForFile(language, filePath, {
-					onStarting: (lang) => ctx.ui.setWorkingMessage(`Starting ${lang} language server`),
-					settingsCwd: ctx.cwd,
-					signal,
-				});
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
+			return sendAndFormat(
+				setup.conn,
+				protocolBindings.ReferencesRequest.type,
+				{
+					textDocument: { uri: filePathToUri(setup.filePath) },
+					position: { line: params.line - 1, character: params.character - 1 },
+					context: { includeDeclaration: params.includeDeclaration ?? true },
+				},
+				signal,
+				"LSP references request",
+				(result: Location[] | null) => {
+					const locations = result || [];
+					return `Found ${locations.length} reference(s):\n${formatLocations(locations)}`;
 				}
-				if (isTimeoutError(error)) {
-					return {
-						details: {},
-						content: [
-							{
-								type: "text",
-								text: `Language server startup timed out for ${language}`,
-							},
-						],
-						isError: true,
-					};
-				}
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Error starting language server: ${error}`,
-						},
-					],
-					isError: true,
-				};
-			} finally {
-				ctx.ui.setWorkingMessage();
-			}
-
-			if (!conn) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Language server not available for ${language}` }],
-				};
-			}
-
-			if (!conn.capabilities.referencesProvider) {
-				return {
-					details: {},
-					content: [{ type: "text", text: "References provider not supported" }],
-				};
-			}
-
-			await openDocument(conn, filePath);
-
-			try {
-				const result = (await sendRequestWithTimeout(
-					conn,
-					protocolBindings.ReferencesRequest.type,
-					{
-						textDocument: { uri: filePathToUri(filePath) },
-						position: { line: params.line - 1, character: params.character - 1 },
-						context: { includeDeclaration: params.includeDeclaration ?? true },
-					},
-					signal,
-					"LSP references request"
-				)) as Location[] | null;
-
-				const locations = result || [];
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Found ${locations.length} reference(s):\n${formatLocations(locations)}`,
-						},
-					],
-				};
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						content: [{ type: "text", text: "References request timed out" }],
-						details: {},
-						isError: true,
-					};
-				}
-				return {
-					content: [{ type: "text", text: `Error: ${error}` }],
-					details: {},
-					isError: true,
-				};
-			}
+			);
 		},
 	});
 
@@ -1233,104 +1192,26 @@ WHEN TO USE:
 			character: Type.Number({ description: "Character/column position (1-indexed)" }),
 		}),
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file)
-				? params.file
-				: path.resolve(ctx.cwd, params.file);
-			const language = getLanguageForFile(filePath);
+			const setup = await withFileConnection(
+				params,
+				signal,
+				ctx,
+				"hoverProvider",
+				"Hover provider"
+			);
+			if (!("conn" in setup)) return setup;
 
-			if (!language) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Unsupported file type: ${params.file}` }],
-				};
-			}
-
-			let conn: LSPConnection | null = null;
-			try {
-				conn = await getOrCreateConnectionForFile(language, filePath, {
-					onStarting: (lang) => ctx.ui.setWorkingMessage(`Starting ${lang} language server`),
-					settingsCwd: ctx.cwd,
-					signal,
-				});
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						details: {},
-						content: [
-							{
-								type: "text",
-								text: `Language server startup timed out for ${language}`,
-							},
-						],
-						isError: true,
-					};
-				}
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Error starting language server: ${error}`,
-						},
-					],
-					isError: true,
-				};
-			} finally {
-				ctx.ui.setWorkingMessage();
-			}
-
-			if (!conn) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Language server not available for ${language}` }],
-				};
-			}
-
-			if (!conn.capabilities.hoverProvider) {
-				return {
-					details: {},
-					content: [{ type: "text", text: "Hover provider not supported" }],
-				};
-			}
-
-			await openDocument(conn, filePath);
-
-			try {
-				const result = (await sendRequestWithTimeout(
-					conn,
-					protocolBindings.HoverRequest.type,
-					{
-						textDocument: { uri: filePathToUri(filePath) },
-						position: { line: params.line - 1, character: params.character - 1 },
-					},
-					signal,
-					"LSP hover request"
-				)) as Hover | null;
-
-				return {
-					details: {},
-					content: [{ type: "text", text: formatHover(result) }],
-				};
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						content: [{ type: "text", text: "Hover request timed out" }],
-						details: {},
-						isError: true,
-					};
-				}
-				return {
-					content: [{ type: "text", text: `Error: ${error}` }],
-					details: {},
-					isError: true,
-				};
-			}
+			return sendAndFormat(
+				setup.conn,
+				protocolBindings.HoverRequest.type,
+				{
+					textDocument: { uri: filePathToUri(setup.filePath) },
+					position: { line: params.line - 1, character: params.character - 1 },
+				},
+				signal,
+				"LSP hover request",
+				(result: Hover | null) => formatHover(result)
+			);
 		},
 	});
 
@@ -1348,103 +1229,23 @@ WHEN TO USE:
 			file: Type.String({ description: "Path to the file" }),
 		}),
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file)
-				? params.file
-				: path.resolve(ctx.cwd, params.file);
-			const language = getLanguageForFile(filePath);
+			const setup = await withFileConnection(
+				params,
+				signal,
+				ctx,
+				"documentSymbolProvider",
+				"Document symbol provider"
+			);
+			if (!("conn" in setup)) return setup;
 
-			if (!language) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Unsupported file type: ${params.file}` }],
-				};
-			}
-
-			let conn: LSPConnection | null = null;
-			try {
-				conn = await getOrCreateConnectionForFile(language, filePath, {
-					onStarting: (lang) => ctx.ui.setWorkingMessage(`Starting ${lang} language server`),
-					settingsCwd: ctx.cwd,
-					signal,
-				});
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						details: {},
-						content: [
-							{
-								type: "text",
-								text: `Language server startup timed out for ${language}`,
-							},
-						],
-						isError: true,
-					};
-				}
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Error starting language server: ${error}`,
-						},
-					],
-					isError: true,
-				};
-			} finally {
-				ctx.ui.setWorkingMessage();
-			}
-
-			if (!conn) {
-				return {
-					details: {},
-					content: [{ type: "text", text: `Language server not available for ${language}` }],
-				};
-			}
-
-			if (!conn.capabilities.documentSymbolProvider) {
-				return {
-					details: {},
-					content: [{ type: "text", text: "Document symbol provider not supported" }],
-				};
-			}
-
-			await openDocument(conn, filePath);
-
-			try {
-				const result = (await sendRequestWithTimeout(
-					conn,
-					protocolBindings.DocumentSymbolRequest.type,
-					{
-						textDocument: { uri: filePathToUri(filePath) },
-					},
-					signal,
-					"LSP document symbols request"
-				)) as (SymbolInformation | DocumentSymbol)[] | null;
-
-				return {
-					details: {},
-					content: [{ type: "text", text: formatSymbols(result) }],
-				};
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
-				}
-				if (isTimeoutError(error)) {
-					return {
-						content: [{ type: "text", text: "Document symbols request timed out" }],
-						details: {},
-						isError: true,
-					};
-				}
-				return {
-					content: [{ type: "text", text: `Error: ${error}` }],
-					details: {},
-					isError: true,
-				};
-			}
+			return sendAndFormat(
+				setup.conn,
+				protocolBindings.DocumentSymbolRequest.type,
+				{ textDocument: { uri: filePathToUri(setup.filePath) } },
+				signal,
+				"LSP document symbols request",
+				(result: (SymbolInformation | DocumentSymbol)[] | null) => formatSymbols(result)
+			);
 		},
 	});
 
@@ -1504,44 +1305,18 @@ WHEN TO USE:
 				};
 			}
 
-			try {
-				const result = (await sendRequestWithTimeout(
-					conn,
-					protocolBindings.WorkspaceSymbolRequest.type,
-					{
-						query: params.query,
-					},
-					signal,
-					"LSP workspace symbols request"
-				)) as (SymbolInformation | WorkspaceSymbol)[] | null;
-
-				const symbols = result || [];
-				return {
-					details: {},
-					content: [
-						{
-							type: "text",
-							text: `Found ${symbols.length} symbol(s) in ${conn.rootPath}:\n${formatSymbols(symbols)}`,
-						},
-					],
-				};
-			} catch (error) {
-				if (isAbortError(error)) {
-					throw error;
+			const rootPath = conn.rootPath;
+			return sendAndFormat(
+				conn,
+				protocolBindings.WorkspaceSymbolRequest.type,
+				{ query: params.query },
+				signal,
+				"LSP workspace symbols request",
+				(result: (SymbolInformation | WorkspaceSymbol)[] | null) => {
+					const symbols = result || [];
+					return `Found ${symbols.length} symbol(s) in ${rootPath}:\n${formatSymbols(symbols)}`;
 				}
-				if (isTimeoutError(error)) {
-					return {
-						content: [{ type: "text", text: "Workspace symbols request timed out" }],
-						details: {},
-						isError: true,
-					};
-				}
-				return {
-					content: [{ type: "text", text: `Error: ${error}` }],
-					details: {},
-					isError: true,
-				};
-			}
+			);
 		},
 	});
 


### PR DESCRIPTION
## Summary

Addresses SonarCloud quality gate failure for duplication (4.7% > 3% threshold) from commit d9b906f.

### Production code

**`extensions/lsp/index.ts`** (−226 lines, 1690 → 1464)
- Extract `withFileConnection()` — resolves file, detects language, gets/creates connection, checks capability, opens document
- Extract `sendAndFormat()` — sends LSP request with timeout/abort handling, formats result
- Refactor all 5 tool handlers (`lsp_definition`, `lsp_references`, `lsp_hover`, `lsp_symbols`, `lsp_workspace_symbols`) to use shared helpers
- Eliminates ~25 duplicated blocks (was 24% duplication)

### Test files

| File | Δ | Extraction |
|------|---|------------|
| `shell-policy-confirm.test.ts` | −41 | `createResultTracker()` replaces 7 inline copies |
| `nested-rules.test.ts` | −28 | `initAndGetPrompt()` replaces 7 inline fire-event blocks |
| `lsp-timeouts.test.ts` | ~0 | `runWithHangingInit()` replaces 4 inline blocks |
| `lsp-tools.test.ts` | 1 line | Fix assertion for consistent timeout message |

**Net: −372 lines (330 added, 702 removed)**

## Verification

- [x] `bun run typecheck` passes
- [x] `bun run typecheck:extensions` passes
- [x] `bun run lint` passes (0 warnings)
- [x] All 2040 tests pass, 0 failures