### PR TITLE
fix(bash): use process.cwd() at execution time instead of stale closure

### DIFF
--- a/extensions/bash-tool-enhanced/index.ts
+++ b/extensions/bash-tool-enhanced/index.ts
@@ -264,7 +264,9 @@ function detectRipgrep(): boolean {
 }
 
 export default function bashLive(pi: ExtensionAPI): void {
-	const baseBashTool = createBashTool(process.cwd());
+	const baseBashTool = createBashTool(process.cwd(), {
+		spawnHook: (ctx) => ({ ...ctx, cwd: process.cwd() }),
+	});
 	const displayConfig = getToolDisplayConfig("bash");
 
 	// Capture project root for BASH_MAINTAIN_PROJECT_WORKING_DIR


### PR DESCRIPTION
## Summary

- Fix `cd` tool changes not persisting for subsequent `bash` tool calls

## Problem

`createBashTool(process.cwd())` captures cwd once at extension load time. The pi framework's bash tool uses this captured value for all `spawn()` calls, ignoring any `process.chdir()` made by the `cd` tool.

Result: `cd` reports success, but bash commands keep running in the original project directory.

## Fix

Add a `spawnHook` that reads `process.cwd()` at execution time:

```typescript
const baseBashTool = createBashTool(process.cwd(), {
  spawnHook: (ctx) => ({ ...ctx, cwd: process.cwd() }),
});
```

`spawnHook` is a first-class option in the pi framework's `BashToolOptions` — designed for exactly this kind of override.

## Testing

- Typechecks pass (core + extensions)
- `BASH_MAINTAIN_PROJECT_WORKING_DIR` interaction verified: command-level `cd` prefix still takes precedence over spawn cwd
- Auto-background promotion unaffected (execution still goes through `baseBashTool.execute()`)