### PR TITLE
test(core): add unit tests for auth-hardening, config, process-cleanup, startup-timing

### DIFF
--- a/skills/tallow-expert/SKILL.md
+++ b/skills/tallow-expert/SKILL.md
@@ -34,7 +34,7 @@ Relay that answer to the user.
 | Component | Location |
 |-----------|----------|
 | Core source | `src/` (agent-runner.ts, atomic-write.ts, auth-hardening.ts, cli.ts, config.ts, extensions-global.d.ts, fatal-errors.ts, index.ts, install.ts, interactive-mode-patch.ts, pid-manager.ts, plugins.ts, process-cleanup.ts, project-trust-banner.ts, project-trust.ts, runtime-path-provider.ts, sdk.ts, session-migration.ts, session-utils.ts, startup-profile.ts, startup-timing.ts) |
-| Extensions | `extensions/` — extension.json + index.ts each (51 bundled) |
+| Extensions | `extensions/` — extension.json + index.ts each (52 bundled) |
 | Skills | `skills/` — subdirs with SKILL.md |
 | Agents | `agents/` — markdown with YAML frontmatter |
 | Themes | `themes/` — JSON files (34 dark-only themes) |

--- a/src/__tests__/auth-hardening-normalize.test.ts
+++ b/src/__tests__/auth-hardening-normalize.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for normalizeApiKeyValue and shell command reference edge cases
+ * in auth-hardening.ts.
+ *
+ * These test the input normalization pipeline that decides whether a key value
+ * is a raw secret, a command reference, an op:// reference, or an env var name.
+ * The public API (persistProviderApiKey) is the primary test surface since
+ * normalizeApiKeyValue is private.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	type ApiKeySecretStore,
+	migratePlaintextApiKeys,
+	persistProviderApiKey,
+} from "../auth-hardening.js";
+
+let tempDir: string | undefined;
+
+/**
+ * Build a temp directory isolated to one test.
+ *
+ * @returns Absolute temp directory path
+ */
+function makeTempDir(): string {
+	const dir = join(
+		tmpdir(),
+		`tallow-auth-norm-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	tempDir = dir;
+	return dir;
+}
+
+/**
+ * Read and parse auth.json.
+ *
+ * @param authPath - auth.json path
+ * @returns Parsed auth object
+ */
+function readAuth(authPath: string): Record<string, { type: string; key: string }> {
+	return JSON.parse(readFileSync(authPath, "utf-8")) as Record<
+		string,
+		{ type: string; key: string }
+	>;
+}
+
+/** Fake store that records calls and returns a command reference. */
+function createFakeStore(): { store: ApiKeySecretStore; calls: string[] } {
+	const calls: string[] = [];
+	const store: ApiKeySecretStore = {
+		store: (provider, apiKey) => {
+			calls.push(`${provider}:${apiKey}`);
+			return `!fake-keychain ${provider}`;
+		},
+	};
+	return { store, calls };
+}
+
+afterEach(() => {
+	if (tempDir && existsSync(tempDir)) {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+	tempDir = undefined;
+});
+
+describe("normalizeApiKeyValue via persistProviderApiKey", () => {
+	test("preserves existing !command references unchanged", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "anthropic", "!pass show api-key", store);
+
+		const data = readAuth(authPath);
+		expect(data.anthropic.key).toBe("!pass show api-key");
+		expect(calls).toHaveLength(0); // Store not called for existing refs
+	});
+
+	test("converts op:// references to opchain command references", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "openai", "op://Services/OpenAI/api-key", store);
+
+		const data = readAuth(authPath);
+		expect(data.openai.key).toBe("!opchain --read op read 'op://Services/OpenAI/api-key'");
+		expect(calls).toHaveLength(0); // Store not called for op:// refs
+	});
+
+	test("preserves ENV_VAR_NAME references unchanged", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "anthropic", "ANTHROPIC_API_KEY", store);
+
+		const data = readAuth(authPath);
+		expect(data.anthropic.key).toBe("ANTHROPIC_API_KEY");
+		expect(calls).toHaveLength(0);
+	});
+
+	test("sends raw keys to the secret store", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "anthropic", "sk-ant-raw-key-123", store);
+
+		expect(calls).toEqual(["anthropic:sk-ant-raw-key-123"]);
+		const data = readAuth(authPath);
+		expect(data.anthropic.key).toBe("!fake-keychain anthropic");
+	});
+
+	test("trims whitespace from key input", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "anthropic", "  ANTHROPIC_API_KEY  ", store);
+
+		expect(data(authPath).anthropic.key).toBe("ANTHROPIC_API_KEY");
+		expect(calls).toHaveLength(0);
+
+		function data(p: string): Record<string, { key: string }> {
+			return JSON.parse(readFileSync(p, "utf-8")) as Record<string, { key: string }>;
+		}
+	});
+
+	test("throws on empty key input", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store } = createFakeStore();
+
+		expect(() => persistProviderApiKey(authPath, "anthropic", "", store)).toThrow("Empty API key");
+	});
+
+	test("throws on whitespace-only key input", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store } = createFakeStore();
+
+		expect(() => persistProviderApiKey(authPath, "anthropic", "   ", store)).toThrow(
+			"Empty API key"
+		);
+	});
+});
+
+describe("ENV_VAR_NAME pattern matching", () => {
+	test("single-word uppercase is NOT an env var (no underscore)", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		// "MYTOKEN" has no underscore — doesn't match the ENV_REFERENCE_PATTERN
+		persistProviderApiKey(authPath, "test", "MYTOKEN", store);
+
+		// Should be treated as raw key → sent to store
+		expect(calls).toHaveLength(1);
+	});
+
+	test("uppercase with underscore is treated as env var reference", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "test", "MY_TOKEN", store);
+
+		expect(calls).toHaveLength(0);
+		const data = readAuth(authPath);
+		expect(data.test.key).toBe("MY_TOKEN");
+	});
+
+	test("mixed case is NOT treated as env var reference", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store, calls } = createFakeStore();
+
+		persistProviderApiKey(authPath, "test", "My_Token", store);
+
+		// Mixed case doesn't match /^[A-Z][A-Z0-9]*_[A-Z0-9_]*$/ → raw key
+		expect(calls).toHaveLength(1);
+	});
+});
+
+describe("migratePlaintextApiKeys edge cases", () => {
+	test("returns empty array for non-existent auth file", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "nonexistent-auth.json");
+		const { store } = createFakeStore();
+
+		const result = migratePlaintextApiKeys(authPath, store);
+
+		expect(result.migratedProviders).toEqual([]);
+	});
+
+	test("skips non-api_key credential types", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				provider1: { type: "oauth", token: "some-token" },
+				provider2: { type: "api_key", key: "ALREADY_A_REF_KEY" },
+			}),
+			{ mode: 0o600 }
+		);
+		const { store, calls } = createFakeStore();
+
+		const result = migratePlaintextApiKeys(authPath, store);
+
+		// provider1 is oauth (skipped), provider2 already has env ref (no migration needed)
+		expect(result.migratedProviders).toEqual([]);
+		expect(calls).toHaveLength(0);
+	});
+
+	test("handles corrupted auth file by recovering from backup", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		writeFileSync(authPath, "not valid json", { mode: 0o600 });
+		const { store } = createFakeStore();
+
+		// Should not throw — readAuthData catches parse errors
+		const result = migratePlaintextApiKeys(authPath, store);
+		expect(result.migratedProviders).toEqual([]);
+	});
+
+	test("does not write file when no changes are needed", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const content = JSON.stringify(
+			{ anthropic: { type: "api_key", key: "ANTHROPIC_API_KEY" } },
+			null,
+			2
+		);
+		writeFileSync(authPath, content, { mode: 0o600 });
+		const { store } = createFakeStore();
+
+		const result = migratePlaintextApiKeys(authPath, store);
+
+		expect(result.migratedProviders).toEqual([]);
+	});
+});
+
+describe("op:// reference conversion", () => {
+	test("single-quotes the op:// reference in the command", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store } = createFakeStore();
+
+		persistProviderApiKey(authPath, "test", "op://Vault/Item With Spaces/field", store);
+
+		const data = readAuth(authPath);
+		expect(data.test.key).toBe("!opchain --read op read 'op://Vault/Item With Spaces/field'");
+	});
+
+	test("escapes single quotes within op:// reference", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store } = createFakeStore();
+
+		persistProviderApiKey(authPath, "test", "op://Vault/It's/field", store);
+
+		const data = readAuth(authPath);
+		// Shell escaping: ' → '\'' (close quote, escaped literal, reopen quote)
+		expect(data.test.key).toContain("'op://Vault/It'\\''s/field'");
+	});
+});
+
+describe("persistProviderApiKey return value", () => {
+	test("returns 'keychain' for keychain command references", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const keychainStore: ApiKeySecretStore = {
+			store: () => "!security find-generic-password -w -a 'tallow' -s 'tallow.api-key.test'",
+		};
+
+		const mode = persistProviderApiKey(authPath, "test", "raw-key", keychainStore);
+		expect(mode).toBe("keychain");
+	});
+
+	test("returns 'reference' for non-keychain references", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const envStore: ApiKeySecretStore = {
+			store: () => "!custom-secret-tool get test",
+		};
+
+		const mode = persistProviderApiKey(authPath, "test", "raw-key", envStore);
+		expect(mode).toBe("reference");
+	});
+
+	test("returns 'reference' for env var references", () => {
+		const dir = makeTempDir();
+		const authPath = join(dir, "auth.json");
+		const { store } = createFakeStore();
+
+		const mode = persistProviderApiKey(authPath, "test", "MY_API_KEY", store);
+		expect(mode).toBe("reference");
+	});
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for src/config.ts — identity constants, path resolution, demo mode,
+ * .env parsing, and bootstrap behavior.
+ *
+ * Tests that touch process.env save/restore original values in afterEach
+ * to avoid cross-test contamination.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+
+// ─── Env snapshot helpers ────────────────────────────────────────────────────
+
+/** Environment variables touched by tests — saved/restored per test. */
+const ENV_KEYS = ["IS_DEMO", "TALLOW_DEMO", "USER", "USERNAME"] as const;
+
+type EnvSnapshot = Record<string, string | undefined>;
+
+/**
+ * Capture current values for a set of env keys.
+ *
+ * @returns Snapshot of current env values
+ */
+function captureEnv(): EnvSnapshot {
+	const snap: EnvSnapshot = {};
+	for (const key of ENV_KEYS) {
+		snap[key] = process.env[key];
+	}
+	return snap;
+}
+
+/**
+ * Restore env to a previously captured snapshot.
+ *
+ * @param snap - Snapshot to restore
+ */
+function restoreEnv(snap: EnvSnapshot): void {
+	for (const [key, value] of Object.entries(snap)) {
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+}
+
+// ─── Temp dir management ─────────────────────────────────────────────────────
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────
+
+let envSnap: EnvSnapshot;
+
+beforeEach(() => {
+	envSnap = captureEnv();
+});
+
+afterEach(() => {
+	restoreEnv(envSnap);
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("identity constants", () => {
+	test("APP_NAME is tallow", async () => {
+		const { APP_NAME } = await import("../config.js");
+		expect(APP_NAME).toBe("tallow");
+	});
+
+	test("CONFIG_DIR is .tallow", async () => {
+		const { CONFIG_DIR } = await import("../config.js");
+		expect(CONFIG_DIR).toBe(".tallow");
+	});
+
+	test("TALLOW_VERSION matches semver pattern", async () => {
+		const { TALLOW_VERSION } = await import("../config.js");
+		expect(TALLOW_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+	});
+});
+
+describe("BUNDLED paths", () => {
+	test("BUNDLED paths reference existing directories", async () => {
+		const { BUNDLED } = await import("../config.js");
+		expect(existsSync(BUNDLED.extensions)).toBe(true);
+		expect(existsSync(BUNDLED.skills)).toBe(true);
+		expect(existsSync(BUNDLED.themes)).toBe(true);
+	});
+});
+
+describe("TEMPLATES paths", () => {
+	test("TEMPLATES paths reference existing directories", async () => {
+		const { TEMPLATES } = await import("../config.js");
+		expect(existsSync(TEMPLATES.agents)).toBe(true);
+		expect(existsSync(TEMPLATES.commands)).toBe(true);
+	});
+});
+
+describe("isDemoMode", () => {
+	test("returns false when no demo env vars are set", async () => {
+		delete process.env.IS_DEMO;
+		delete process.env.TALLOW_DEMO;
+		const { isDemoMode } = await import("../config.js");
+		expect(isDemoMode()).toBe(false);
+	});
+
+	test("returns true when IS_DEMO=1", async () => {
+		process.env.IS_DEMO = "1";
+		delete process.env.TALLOW_DEMO;
+		const { isDemoMode } = await import("../config.js");
+		expect(isDemoMode()).toBe(true);
+	});
+
+	test("returns true when TALLOW_DEMO=1", async () => {
+		delete process.env.IS_DEMO;
+		process.env.TALLOW_DEMO = "1";
+		const { isDemoMode } = await import("../config.js");
+		expect(isDemoMode()).toBe(true);
+	});
+
+	test("returns false when demo vars are set to non-1 values", async () => {
+		process.env.IS_DEMO = "0";
+		process.env.TALLOW_DEMO = "false";
+		const { isDemoMode } = await import("../config.js");
+		expect(isDemoMode()).toBe(false);
+	});
+});
+
+describe("sanitizePath", () => {
+	test("returns path unchanged when demo mode is off", async () => {
+		delete process.env.IS_DEMO;
+		delete process.env.TALLOW_DEMO;
+		const { sanitizePath } = await import("../config.js");
+		const path = "/Users/kevin/dev/tallow/src/config.ts";
+		expect(sanitizePath(path)).toBe(path);
+	});
+
+	test("replaces username with demo when demo mode is active", async () => {
+		process.env.IS_DEMO = "1";
+		process.env.USER = "kevin";
+		const { sanitizePath } = await import("../config.js");
+		expect(sanitizePath("/Users/kevin/dev/tallow")).toBe("/Users/demo/dev/tallow");
+	});
+
+	test("replaces multiple username occurrences in a path", async () => {
+		process.env.IS_DEMO = "1";
+		process.env.USER = "kevin";
+		const { sanitizePath } = await import("../config.js");
+		expect(sanitizePath("/Users/kevin/dev/kevin/project")).toBe("/Users/demo/dev/demo/project");
+	});
+
+	test("returns path unchanged when USER is not set in demo mode", async () => {
+		process.env.IS_DEMO = "1";
+		delete process.env.USER;
+		delete process.env.USERNAME;
+		const { sanitizePath } = await import("../config.js");
+		const path = "/Users/someone/dev";
+		expect(sanitizePath(path)).toBe(path);
+	});
+
+	test("handles trailing username in path", async () => {
+		process.env.IS_DEMO = "1";
+		process.env.USER = "kevin";
+		const { sanitizePath } = await import("../config.js");
+		expect(sanitizePath("/home/kevin")).toBe("/home/demo");
+	});
+
+	test("falls back to USERNAME when USER is unset", async () => {
+		process.env.IS_DEMO = "1";
+		delete process.env.USER;
+		process.env.USERNAME = "winuser";
+		const { sanitizePath } = await import("../config.js");
+		expect(sanitizePath("/Users/winuser/project")).toBe("/Users/demo/project");
+	});
+});
+
+describe("getRuntimeTallowHome", () => {
+	test("returns TALLOW_HOME when env override is not set", async () => {
+		const { getRuntimeTallowHome, TALLOW_HOME } = await import("../config.js");
+		const original = process.env.TALLOW_HOME;
+		delete process.env.TALLOW_HOME;
+		const result = getRuntimeTallowHome();
+		// Restore
+		if (original !== undefined) process.env.TALLOW_HOME = original;
+		expect(result).toBe(TALLOW_HOME);
+	});
+
+	test("returns env override when TALLOW_HOME is set", async () => {
+		const { getRuntimeTallowHome } = await import("../config.js");
+		const original = process.env.TALLOW_HOME;
+		process.env.TALLOW_HOME = "/tmp/override-home";
+		const result = getRuntimeTallowHome();
+		// Restore
+		if (original !== undefined) {
+			process.env.TALLOW_HOME = original;
+		} else {
+			delete process.env.TALLOW_HOME;
+		}
+		expect(result).toBe("/tmp/override-home");
+	});
+});
+
+describe("getRuntimePathProvider / setRuntimePathProviderForTests", () => {
+	test("returns default provider when no override is set", async () => {
+		const { getRuntimePathProvider, setRuntimePathProviderForTests } = await import("../config.js");
+		setRuntimePathProviderForTests(); // reset
+		const provider = getRuntimePathProvider();
+		expect(typeof provider.getHomeDir).toBe("function");
+		expect(typeof provider.getRunDir).toBe("function");
+	});
+
+	test("returns override provider when set, and resets on undefined", async () => {
+		const { getRuntimePathProvider, setRuntimePathProviderForTests } = await import("../config.js");
+		const { createStaticRuntimePathProvider } = await import("../runtime-path-provider.js");
+
+		const custom = createStaticRuntimePathProvider("/tmp/custom-home");
+		setRuntimePathProviderForTests(custom);
+
+		expect(getRuntimePathProvider().getHomeDir()).toBe("/tmp/custom-home");
+
+		setRuntimePathProviderForTests(); // reset
+		const defaultProvider = getRuntimePathProvider();
+		expect(defaultProvider).not.toBe(custom);
+	});
+});
+
+describe("bootstrap side effects", () => {
+	test("sets process.title to tallow", async () => {
+		const { bootstrap } = await import("../config.js");
+		const originalTitle = process.title;
+		bootstrap();
+		expect(process.title).toBe("tallow");
+		process.title = originalTitle;
+	});
+});
+
+describe("env var module-scope exports", () => {
+	test("PI_PACKAGE_DIR is set to PACKAGE_DIR", async () => {
+		const { PACKAGE_DIR } = await import("../config.js");
+		expect(process.env.PI_PACKAGE_DIR).toBe(PACKAGE_DIR);
+	});
+
+	test("PI_SKIP_VERSION_CHECK is 1", () => {
+		expect(process.env.PI_SKIP_VERSION_CHECK).toBe("1");
+	});
+});
+
+describe("resolveOpSecrets", () => {
+	test("no-ops when .env file does not exist", async () => {
+		const { resolveOpSecrets } = await import("../config.js");
+		// This should not throw even when TALLOW_HOME points to a non-existent dir.
+		// The function catches the file-read error and returns early.
+		await expect(resolveOpSecrets()).resolves.toBeUndefined();
+	});
+});

--- a/src/__tests__/process-cleanup.test.ts
+++ b/src/__tests__/process-cleanup.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for src/process-cleanup.ts — signal handlers and stream error recovery.
+ *
+ * Since registerProcessCleanup installs signal handlers that call process.exit,
+ * tests run scenarios in child processes to avoid killing the test runner.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let testDir: string;
+
+beforeEach(() => {
+	testDir = mkdtempSync(join(tmpdir(), "tallow-cleanup-test-"));
+});
+
+afterEach(() => {
+	if (existsSync(testDir)) {
+		rmSync(testDir, { recursive: true, force: true });
+	}
+});
+
+/**
+ * Run a child process that imports process-cleanup and executes a test script.
+ *
+ * @param script - Inline JS to execute after importing the module
+ * @returns Exit code, stdout, and stderr
+ */
+async function runCleanupScenario(script: string): Promise<{
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}> {
+	const distDir = join(process.cwd(), "dist");
+	const fullScript = `
+		const { registerProcessCleanup } = await import(${JSON.stringify(join(distDir, "process-cleanup.js"))});
+		${script}
+	`;
+
+	const proc = Bun.spawn(["node", "--input-type=module", "-e", fullScript], {
+		env: {
+			...process.env,
+			TALLOW_HOME: testDir,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	const [stdout, stderr] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+
+	const exitCode = await proc.exited;
+	return { exitCode, stdout, stderr };
+}
+
+describe("registerProcessCleanup", () => {
+	test("returns a mutable session ref", async () => {
+		const { exitCode, stdout } = await runCleanupScenario(`
+			const ref = registerProcessCleanup();
+			// The ref is a plain object — current starts as undefined
+			const isObject = typeof ref === "object" && ref !== null;
+			const currentIsUndefined = ref.current === undefined;
+			// Verify mutability
+			ref.current = "test-session";
+			const canMutate = ref.current === "test-session";
+			process.stdout.write(JSON.stringify({ isObject, currentIsUndefined, canMutate }));
+			process.exit(0);
+		`);
+
+		expect(exitCode).toBe(0);
+		const result = JSON.parse(stdout);
+		expect(result.isObject).toBe(true);
+		expect(result.currentIsUndefined).toBe(true);
+		expect(result.canMutate).toBe(true);
+	});
+
+	test("handles SIGTERM with exit code 143", async () => {
+		const { exitCode } = await runCleanupScenario(`
+			registerProcessCleanup();
+			// Send SIGTERM to self after a brief delay
+			setTimeout(() => process.kill(process.pid, "SIGTERM"), 50);
+			// Keep alive long enough for the signal
+			setTimeout(() => {}, 5000);
+		`);
+
+		// SIGTERM → cleanup → exit(143)
+		expect(exitCode).toBe(143);
+	});
+
+	test("handles SIGINT with exit code 130", async () => {
+		const { exitCode } = await runCleanupScenario(`
+			registerProcessCleanup();
+			setTimeout(() => process.kill(process.pid, "SIGINT"), 50);
+			setTimeout(() => {}, 5000);
+		`);
+
+		expect(exitCode).toBe(130);
+	});
+
+	test("second signal during cleanup forces immediate exit", async () => {
+		// Send two SIGTERMs in rapid succession — the second should force-exit
+		const { exitCode } = await runCleanupScenario(`
+			registerProcessCleanup();
+			setTimeout(() => {
+				process.kill(process.pid, "SIGTERM");
+				// Second signal 10ms later should force immediate exit
+				setTimeout(() => process.kill(process.pid, "SIGTERM"), 10);
+			}, 50);
+			setTimeout(() => {}, 5000);
+		`);
+
+		expect(exitCode).toBe(143);
+	});
+});

--- a/src/__tests__/startup-timing.test.ts
+++ b/src/__tests__/startup-timing.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for src/startup-timing.ts — timing emission, env-gating, and output format.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	emitStartupTiming,
+	isStartupTimingEnabled,
+	STARTUP_TIMING_PREFIX,
+} from "../startup-timing.js";
+
+/** Original env value for TALLOW_STARTUP_TIMING. */
+let originalTimingEnv: string | undefined;
+
+/** Captured stderr writes during a test. */
+let stderrWrites: string[];
+
+/** Original process.stderr.write before monkey-patching. */
+let originalStderrWrite: typeof process.stderr.write;
+
+beforeEach(() => {
+	originalTimingEnv = process.env.TALLOW_STARTUP_TIMING;
+	stderrWrites = [];
+	originalStderrWrite = process.stderr.write;
+	process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+		stderrWrites.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+		return true;
+	}) as typeof process.stderr.write;
+});
+
+afterEach(() => {
+	process.stderr.write = originalStderrWrite;
+	if (originalTimingEnv !== undefined) {
+		process.env.TALLOW_STARTUP_TIMING = originalTimingEnv;
+	} else {
+		delete process.env.TALLOW_STARTUP_TIMING;
+	}
+});
+
+// ─── isStartupTimingEnabled ──────────────────────────────────────────────────
+
+describe("isStartupTimingEnabled", () => {
+	test("returns false when env var is not set", () => {
+		delete process.env.TALLOW_STARTUP_TIMING;
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("returns false for empty string", () => {
+		process.env.TALLOW_STARTUP_TIMING = "";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("returns true for '1'", () => {
+		process.env.TALLOW_STARTUP_TIMING = "1";
+		expect(isStartupTimingEnabled()).toBe(true);
+	});
+
+	test("returns true for 'true'", () => {
+		process.env.TALLOW_STARTUP_TIMING = "true";
+		expect(isStartupTimingEnabled()).toBe(true);
+	});
+
+	test("returns true for arbitrary non-disabled values", () => {
+		process.env.TALLOW_STARTUP_TIMING = "verbose";
+		expect(isStartupTimingEnabled()).toBe(true);
+	});
+
+	test("returns false for '0'", () => {
+		process.env.TALLOW_STARTUP_TIMING = "0";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("returns false for 'false'", () => {
+		process.env.TALLOW_STARTUP_TIMING = "false";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("returns false for 'off'", () => {
+		process.env.TALLOW_STARTUP_TIMING = "off";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("returns false for 'no'", () => {
+		process.env.TALLOW_STARTUP_TIMING = "no";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("disabled values are case-insensitive", () => {
+		process.env.TALLOW_STARTUP_TIMING = "FALSE";
+		expect(isStartupTimingEnabled()).toBe(false);
+
+		process.env.TALLOW_STARTUP_TIMING = "Off";
+		expect(isStartupTimingEnabled()).toBe(false);
+
+		process.env.TALLOW_STARTUP_TIMING = "NO";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+
+	test("trims whitespace from disabled values", () => {
+		process.env.TALLOW_STARTUP_TIMING = "  false  ";
+		expect(isStartupTimingEnabled()).toBe(false);
+	});
+});
+
+// ─── emitStartupTiming ──────────────────────────────────────────────────────
+
+describe("emitStartupTiming", () => {
+	test("writes nothing when timing is disabled", () => {
+		delete process.env.TALLOW_STARTUP_TIMING;
+		emitStartupTiming("test_metric", 42.123456);
+		expect(stderrWrites).toHaveLength(0);
+	});
+
+	test("writes JSON payload when timing is enabled", () => {
+		process.env.TALLOW_STARTUP_TIMING = "1";
+		emitStartupTiming("extension_load", 123.456789);
+
+		expect(stderrWrites).toHaveLength(1);
+		const line = stderrWrites[0];
+		expect(line).toStartWith(STARTUP_TIMING_PREFIX);
+		expect(line).toEndWith("\n");
+
+		const jsonPart = line.slice(STARTUP_TIMING_PREFIX.length + 1, -1);
+		const payload = JSON.parse(jsonPart) as {
+			metric: string;
+			milliseconds: number;
+			ts: string;
+		};
+		expect(payload.metric).toBe("extension_load");
+		expect(payload.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	test("rounds milliseconds to 3 decimal places", () => {
+		process.env.TALLOW_STARTUP_TIMING = "1";
+		emitStartupTiming("rounding_test", 1.23456789);
+
+		const line = stderrWrites[0];
+		const jsonPart = line.slice(STARTUP_TIMING_PREFIX.length + 1, -1);
+		const payload = JSON.parse(jsonPart) as { milliseconds: number };
+		expect(payload.milliseconds).toBe(1.235);
+	});
+
+	test("rounds whole numbers cleanly", () => {
+		process.env.TALLOW_STARTUP_TIMING = "1";
+		emitStartupTiming("whole_test", 100);
+
+		const line = stderrWrites[0];
+		const jsonPart = line.slice(STARTUP_TIMING_PREFIX.length + 1, -1);
+		const payload = JSON.parse(jsonPart) as { milliseconds: number };
+		expect(payload.milliseconds).toBe(100);
+	});
+
+	test("includes metadata in payload", () => {
+		process.env.TALLOW_STARTUP_TIMING = "1";
+		emitStartupTiming("meta_test", 50, { extensionName: "mcp-adapter", count: 3 });
+
+		const line = stderrWrites[0];
+		const jsonPart = line.slice(STARTUP_TIMING_PREFIX.length + 1, -1);
+		const payload = JSON.parse(jsonPart) as {
+			metric: string;
+			extensionName: string;
+			count: number;
+		};
+		expect(payload.extensionName).toBe("mcp-adapter");
+		expect(payload.count).toBe(3);
+	});
+
+	test("uses STARTUP_TIMING_PREFIX constant as line prefix", () => {
+		expect(STARTUP_TIMING_PREFIX).toBe("TALLOW_STARTUP_TIMING");
+	});
+
+	test("output format matches TALLOW_STARTUP_TIMING {json}", () => {
+		process.env.TALLOW_STARTUP_TIMING = "1";
+		emitStartupTiming("format_test", 0);
+
+		const line = stderrWrites[0];
+		// Format: "TALLOW_STARTUP_TIMING {json}\n"
+		expect(line).toMatch(new RegExp(`^${STARTUP_TIMING_PREFIX} \\{.+\\}\n$`));
+	});
+});


### PR DESCRIPTION
## Summary

- Add 64 unit tests covering 4 previously untested `src/` modules

## Changes Made

- `auth-hardening-normalize.test.ts` (19 tests): API key normalization pipeline — `!command` refs, `op://` → opchain conversion, env var detection, raw key → keychain store, migration edge cases
- `config.test.ts` (23 tests): identity constants, path resolution, demo mode sanitization, bootstrap side effects, `TALLOW_HOME` override, runtime path providers
- `process-cleanup.test.ts` (4 tests): SIGTERM/SIGINT exit codes, double-signal force-exit, session ref lifecycle (runs scenarios in child processes)
- `startup-timing.test.ts` (18 tests): `TALLOW_STARTUP_TIMING` env gating, JSON payload format, millisecond rounding, metadata inclusion

## Testing

- All 458 tests pass (`bun test`)
- All hooks pass (typecheck core + extensions, lint)