### PR TITLE
fix(ci): resolve audit and lint failures

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
     "@mariozechner/pi-coding-agent>@mariozechner/pi-tui": "workspace:*",
     "@mariozechner/pi-tui": "workspace:*",
     "ajv": "8.18.0",
+    "basic-ftp": "5.2.0",
     "fast-xml-parser": "5.3.6",
     "minimatch": "10.2.1",
   },
@@ -344,7 +345,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "basic-ftp": ["basic-ftp@5.1.0", "", {}, "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw=="],
+    "basic-ftp": ["basic-ftp@5.2.0", "", {}, "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"@mariozechner/pi-tui": "workspace:*",
 		"@mariozechner/pi-coding-agent>@mariozechner/pi-tui": "workspace:*",
 		"ajv": "8.18.0",
+		"basic-ftp": "5.2.0",
 		"fast-xml-parser": "5.3.6",
 		"minimatch": "10.2.1"
 	},

--- a/scripts/copy-pi-themes.mjs
+++ b/scripts/copy-pi-themes.mjs
@@ -16,7 +16,15 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const THEME_FILES = ["dark.json", "light.json", "theme-schema.json"];
-const PI_THEMES = join("node_modules", "@mariozechner", "pi-coding-agent", "dist", "modes", "interactive", "theme");
+const PI_THEMES = join(
+	"node_modules",
+	"@mariozechner",
+	"pi-coding-agent",
+	"dist",
+	"modes",
+	"interactive",
+	"theme"
+);
 const RELATIVE_PATH = join("modes", "interactive", "theme");
 
 /**


### PR DESCRIPTION
## Summary
- pin `basic-ftp` to `5.2.0` via `overrides` to clear the critical advisory from `bun audit`
- regenerate `bun.lock` with the updated transitive resolution
- format `scripts/copy-pi-themes.mjs` to satisfy Biome CI lint checks

## Why
Recent CI runs on main and PR #103 failed in:
- `audit` job (critical vulnerability in `basic-ftp <5.2.0`)
- `build` job lint step (format drift in `scripts/copy-pi-themes.mjs`)

## Validation
- `bun audit` (no vulnerabilities)
- `bun run typecheck`
- `bun run typecheck:extensions`
- `bunx biome ci .`
- `bun run build`
