### PR TITLE
docs(pr-template): require explicit PR check verification before merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Implementation approach (if non-obvious).
 - [ ] `bun run lint` passes
 - [ ] `bun test` passes
 - [ ] `bun run build` succeeds
+- [ ] All required GitHub checks are green (verify with `gh pr checks <pr-number>`)
 
 ### Docs impact
 


### PR DESCRIPTION
## Summary
Add a merge gate reminder to the PR template checklist:

- [ ] All required GitHub checks are green (verify with `gh pr checks <pr-number>`)

## Why
We had recent merges where only partial signals were checked (e.g. Vercel), while required checks were still failing. This makes explicit check verification part of the review workflow.