### PR TITLE
fix: hide overflow error payload before auto-compaction

### DIFF
--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import { patchInteractiveModePrototype } from "../interactive-mode-patch.js";
 
+interface FakeMessageContent {
+	type: string;
+}
+
+interface FakeMessage {
+	content: FakeMessageContent[];
+	errorMessage?: string;
+	role: "assistant" | "user";
+	stopReason?: "aborted" | "error" | "stop";
+}
+
 interface FakeEvent {
+	message?: FakeMessage;
 	type?: string;
 }
 
@@ -11,6 +23,7 @@ class FakeInteractiveMode {
 	flushCalls = 0;
 	handleBashCommandCalls = 0;
 	handleEventCalls = 0;
+	lastHandledEvent: FakeEvent | undefined;
 	lastRestoredAbort: boolean | undefined;
 	lifecycleCalls: string[] = [];
 	loadingAnimation: unknown;
@@ -34,8 +47,9 @@ class FakeInteractiveMode {
 	 * @param _event - Event payload
 	 * @returns Promise resolved with marker text
 	 */
-	async handleEvent(_event: FakeEvent): Promise<string> {
+	async handleEvent(event: FakeEvent): Promise<string> {
 		this.handleEventCalls++;
+		this.lastHandledEvent = event;
 		return "ok";
 	}
 
@@ -167,6 +181,81 @@ describe("patchInteractiveModePrototype", () => {
 		expect(flushCallIndex).toBeGreaterThanOrEqual(0);
 		expect(updateCallIndex).toBeGreaterThanOrEqual(0);
 		expect(flushCallIndex).toBeLessThan(updateCallIndex);
+	});
+
+	it("suppresses overflow message_end error payloads before render", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+
+		const overflowPayloads = [
+			'Codex error: {"type":"error","code":"context_length_exceeded","message":"prompt is too long"}',
+			// Provider fallback path: HTTP status with no body still signals overflow.
+			"413 (no body)",
+		] as const;
+
+		for (const errorMessage of overflowPayloads) {
+			const mode = new FakeInteractiveMode();
+
+			await mode.handleEvent({
+				type: "message_end",
+				message: {
+					content: [],
+					errorMessage,
+					role: "assistant",
+					stopReason: "error",
+				},
+			});
+
+			expect(mode.lastHandledEvent?.message?.stopReason).toBe("stop");
+			expect(mode.lastHandledEvent?.message?.errorMessage).toBeUndefined();
+		}
+	});
+
+	it("keeps overflow-like message_end errors unchanged when tool calls are present", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+		const originalMessage =
+			'Codex error: {"type":"error","code":"context_length_exceeded","message":"prompt is too long"}';
+
+		await mode.handleEvent({
+			type: "message_end",
+			message: {
+				// keep stopReason=error when tool calls exist so pending tool rows
+				// can resolve correctly in InteractiveMode.
+				content: [{ type: "toolCall" }],
+				errorMessage: originalMessage,
+				role: "assistant",
+				stopReason: "error",
+			},
+		});
+
+		expect(mode.lastHandledEvent?.message?.stopReason).toBe("error");
+		expect(mode.lastHandledEvent?.message?.errorMessage).toBe(originalMessage);
+	});
+
+	it("keeps non-overflow message_end errors unchanged", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+
+		const nonOverflowErrors = [
+			"401 Unauthorized: invalid API key",
+			"413 Request Entity Too Large",
+		] as const;
+
+		for (const originalMessage of nonOverflowErrors) {
+			const mode = new FakeInteractiveMode();
+
+			await mode.handleEvent({
+				type: "message_end",
+				message: {
+					content: [],
+					errorMessage: originalMessage,
+					role: "assistant",
+					stopReason: "error",
+				},
+			});
+
+			expect(mode.lastHandledEvent?.message?.stopReason).toBe("error");
+			expect(mode.lastHandledEvent?.message?.errorMessage).toBe(originalMessage);
+		}
 	});
 
 	it("flushes deferred bash output after wrapped handleBashCommand and refreshes UI", async () => {

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -7,6 +7,11 @@ interface QueuedMessagesLike {
 	steering?: unknown[];
 }
 
+interface SessionLike {
+	autoCompactionEnabled?: boolean;
+	isStreaming?: boolean;
+}
+
 interface InteractiveModeInstanceLike {
 	compactionQueuedMessages?: Array<unknown>;
 	defaultEditor?: { onEscape?: (() => void) | undefined };
@@ -15,10 +20,22 @@ interface InteractiveModeInstanceLike {
 	loadingAnimation?: unknown;
 	pendingWorkingMessage?: unknown;
 	restoreQueuedMessagesToEditor?: ((options?: { abort?: boolean }) => unknown) | undefined;
-	session?: { isStreaming?: boolean };
+	session?: SessionLike;
 	statusContainer?: { clear?: (() => void) | undefined };
 	ui?: { requestRender?: (() => void) | undefined };
 	updatePendingMessagesDisplay?: (() => void) | undefined;
+}
+
+interface AssistantMessageLike {
+	content?: unknown[];
+	errorMessage?: string;
+	role?: string;
+	stopReason?: string;
+}
+
+interface InteractiveModeEventLike {
+	message?: AssistantMessageLike;
+	type?: string;
 }
 
 interface InteractiveModePrototypeLike {
@@ -27,7 +44,7 @@ interface InteractiveModePrototypeLike {
 	handleBashCommand?:
 		| ((command: string, excludeFromContext?: boolean) => Promise<unknown>)
 		| undefined;
-	handleEvent?: ((event: { type?: string }) => Promise<unknown>) | undefined;
+	handleEvent?: ((event: InteractiveModeEventLike) => Promise<unknown>) | undefined;
 	setupKeyHandlers?: ((...args: unknown[]) => unknown) | undefined;
 }
 
@@ -63,13 +80,111 @@ function hasQueuedMessages(messages: QueuedMessagesLike | undefined): boolean {
 }
 
 /**
+ * Overflow error patterns mirrored from pi-ai overflow detection.
+ *
+ * Keeping these aligned prevents suppressing errors that would not trigger
+ * compaction, and ensures overflow-specific UI suppression stays targeted.
+ */
+const OVERFLOW_ERROR_PATTERNS = [
+	/prompt is too long/i,
+	/input is too long for requested model/i,
+	/exceeds the context window/i,
+	/input token count.*exceeds the maximum/i,
+	/maximum prompt length is \d+/i,
+	/reduce the length of the messages/i,
+	/maximum context length is \d+ tokens/i,
+	/exceeds the limit of \d+/i,
+	/exceeds the available context size/i,
+	/greater than the context length/i,
+	/context window exceeds limit/i,
+	/exceeded model token limit/i,
+	/context[_ ]length[_ ]exceeded/i,
+	/too many tokens/i,
+	/token limit exceeded/i,
+] as const;
+
+/**
+ * Returns whether assistant content includes tool calls.
+ *
+ * Overflow suppression is only safe when no tool calls are present. Tool-call
+ * error rendering uses stopReason===error to mark pending tool components.
+ *
+ * @param content - Assistant message content blocks
+ * @returns True when at least one content block is a tool call
+ */
+function hasToolCalls(content: unknown[] | undefined): boolean {
+	if (!Array.isArray(content)) return false;
+	return content.some((block) => {
+		if (!block || typeof block !== "object") return false;
+		return (block as { type?: unknown }).type === "toolCall";
+	});
+}
+
+/**
+ * Returns whether an error string matches a context-overflow signature.
+ *
+ * @param errorMessage - Assistant error message
+ * @returns True when the error message indicates context overflow
+ */
+function isContextOverflowErrorMessage(errorMessage: string): boolean {
+	if (OVERFLOW_ERROR_PATTERNS.some((pattern) => pattern.test(errorMessage))) {
+		return true;
+	}
+	// Some providers return only a status code with no body for overflow.
+	return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(errorMessage);
+}
+
+/**
+ * Returns an event payload with overflow assistant error text suppressed for UI rendering.
+ *
+ * For overflow+auto-compaction, the dedicated loader line already communicates
+ * state (`Context overflow detected, Auto-compacting...`). Showing an extra
+ * assistant error line is redundant and noisy, especially for serialized JSON
+ * payloads (for example `Codex error: {...}`).
+ *
+ * The original event/message object must stay untouched: AgentSession keeps
+ * using the same references for persistence and overflow-triggered compaction
+ * checks after listener notifications.
+ *
+ * @param event - Interactive mode event payload
+ * @param session - Session-like state used to inspect auto-compaction setting
+ * @returns Original event or a shallow-cloned event for UI-only rendering
+ */
+function suppressOverflowAssistantErrorLine(
+	event: InteractiveModeEventLike,
+	session: SessionLike | undefined
+): InteractiveModeEventLike {
+	if (session?.autoCompactionEnabled === false) return event;
+	if (event.type !== "message_end") return event;
+	const message = event.message;
+	if (!message || message.role !== "assistant") return event;
+	if (message.stopReason !== "error") return event;
+	if (typeof message.errorMessage !== "string") return event;
+	if (!isContextOverflowErrorMessage(message.errorMessage)) return event;
+	if (hasToolCalls(message.content)) return event;
+
+	// Change stopReason for UI rendering only so assistant-message component
+	// does not inject `Error: <payload>`. Auto-compaction status remains visible.
+	return {
+		...event,
+		message: {
+			...message,
+			errorMessage: undefined,
+			stopReason: "stop",
+		},
+	};
+}
+
+/**
  * Patches InteractiveMode prototype methods to prevent stale UI carry-over.
  *
  * The patch adds:
+ * - overflow error suppression before auto-compaction loader rendering
  * - agent_end cleanup for pending working messages + pending-message refresh
  * - post-bash flush/update so deferred bash output moves inline promptly
  * - idle Escape behavior that clears queued steering/follow-up messages
- * - setWorkingMessage guard so idle non-empty updates don't queue stale text
+ * - extension notify normalization for icon-prefixed error messages
+ * - compaction queue inspection helper for extension UI context
  *
  * @param prototype - InteractiveMode prototype object
  * @returns Nothing
@@ -80,8 +195,13 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 
 	const originalHandleEvent = prototype.handleEvent;
 	if (typeof originalHandleEvent === "function") {
-		prototype.handleEvent = async function (this: InteractiveModeInstanceLike, event) {
-			const result = await originalHandleEvent.call(this, event);
+		prototype.handleEvent = async function (
+			this: InteractiveModeInstanceLike,
+			event: InteractiveModeEventLike
+		) {
+			// Keep AgentSession event references immutable for persistence/compaction checks.
+			const uiEvent = suppressOverflowAssistantErrorLine(event, this.session);
+			const result = await originalHandleEvent.call(this, uiEvent);
 			if (event?.type === "agent_end") {
 				this.pendingWorkingMessage = undefined;
 				// NOTE: Do NOT clear statusContainer here — the original framework


### PR DESCRIPTION
## Summary
- suppress overflow assistant `message_end` error payloads in the interactive UI before rendering
- keep the existing `Context overflow detected, Auto-compacting...` loader UX unchanged
- preserve non-overflow error rendering and tool-call error handling behavior

## Changes Made
- added overflow-specific UI event normalization in `src/interactive-mode-patch.ts`
- kept original event references immutable by cloning only the UI-bound event payload
- added regression coverage in `src/__tests__/interactive-mode-patch.test.ts` for overflow suppression, non-overflow safety, and tool-call safety

## Testing
- `bun test src/__tests__/interactive-mode-patch.test.ts`
- `bun run typecheck`
- `bun run lint`
- pre-commit hook: `typecheck`, `typecheck:extensions`, and `lint-staged`
