### PR TITLE
fix(subagent): use --model instead of --models in subprocess args

### DIFF
--- a/extensions/context-fork/__tests__/context-fork.test.ts
+++ b/extensions/context-fork/__tests__/context-fork.test.ts
@@ -212,16 +212,16 @@ describe("buildForkArgs", () => {
 		expect(lastArg).toContain("Do the thing");
 	});
 
-	test("adds --models when model provided", async () => {
+	test("adds --model when model provided", async () => {
 		const args = await buildForkArgs({ ...baseOptions, model: "claude-sonnet-4-5-20250514" });
-		const modelsIndex = args.indexOf("--models");
-		expect(modelsIndex).toBeGreaterThan(-1);
-		expect(args[modelsIndex + 1]).toBe("claude-sonnet-4-5-20250514");
+		const modelIndex = args.indexOf("--model");
+		expect(modelIndex).toBeGreaterThan(-1);
+		expect(args[modelIndex + 1]).toBe("claude-sonnet-4-5-20250514");
 	});
 
-	test("omits --models when model is undefined", async () => {
+	test("omits --model when model is undefined", async () => {
 		const args = await buildForkArgs(baseOptions);
-		expect(args).not.toContain("--models");
+		expect(args).not.toContain("--model");
 	});
 
 	test("adds --tools when tools provided", async () => {

--- a/extensions/context-fork/spawn.ts
+++ b/extensions/context-fork/spawn.ts
@@ -107,7 +107,7 @@ export async function buildForkArgs(
 	const args: string[] = ["--mode", "json", "-p", "--no-session"];
 
 	if (options.model) {
-		args.push("--models", options.model);
+		args.push("--model", options.model);
 	}
 	if (options.tools && options.tools.length > 0) {
 		args.push("--tools", options.tools.join(","));

--- a/extensions/subagent-tool/process.ts
+++ b/extensions/subagent-tool/process.ts
@@ -677,7 +677,7 @@ export async function spawnBackgroundSubagent(
 		: ["--mode", "json", "-p", "--no-session"];
 	// Use provider-qualified name (e.g. "openai-codex/gpt-5.1") so the child process
 	// resolves to the exact provider the router selected, not just the first match.
-	if (agent.model) args.push("--models", routing.model.displayName);
+	if (agent.model) args.push("--model", routing.model.displayName);
 	const effectiveTools = computeEffectiveTools(agent.tools, agent.disallowedTools);
 	if (effectiveTools && effectiveTools.length > 0) args.push("--tools", effectiveTools.join(","));
 	if (agent.skills && agent.skills.length > 0) {
@@ -1098,7 +1098,7 @@ export async function runSingleAgent(
 		? ["--mode", "json", "-p", "--session", session]
 		: ["--mode", "json", "-p", "--no-session"];
 	// Use provider-qualified name so the child process resolves to the exact provider.
-	if (agent.model) args.push("--models", routing.model.displayName);
+	if (agent.model) args.push("--model", routing.model.displayName);
 	const fgEffectiveTools = computeEffectiveTools(agent.tools, agent.disallowedTools);
 	if (fgEffectiveTools && fgEffectiveTools.length > 0)
 		args.push("--tools", fgEffectiveTools.join(","));


### PR DESCRIPTION
## Summary

- Fix one-character typo (`--models` → `--model`) that broke all subagent and context-fork invocations

## Changes Made

- **`extensions/subagent-tool/process.ts`** — Fix `--models` → `--model` in foreground (line 680) and background (line 1101) subprocess arg construction
- **`extensions/context-fork/spawn.ts`** — Fix `--models` → `--model` in fork subprocess args (line 110)
- **`extensions/context-fork/__tests__/context-fork.test.ts`** — Update test assertions to match the corrected `--model` flag

## Root Cause

The CLI defines `--model` (singular) at `src/cli.ts:74`, but three call sites passed `--models` (plural). Every subprocess immediately failed with `error: unknown option '--models' (Did you mean --model?)`.

## Testing

- ✅ 32/32 context-fork tests pass
- ✅ 155/155 subagent-tool tests pass
- ✅ Typecheck (core + extensions) clean
- ✅ Lint clean (499 files)
- ✅ Zero remaining `--models` occurrences in TypeScript source