### PR TITLE
fix: use @dungle-scrubs/tallow in install docs and revert dual-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,7 @@ jobs:
       - name: Strip bun workspace overrides before npm publish
         run: node -e "const p=require('./package.json'); delete p.overrides; require('fs').writeFileSync('package.json', JSON.stringify(p, null, '\t') + '\n')"
 
-      - name: Publish @dungle-scrubs/tallow with OIDC provenance
+      - name: Publish with OIDC provenance
         run: npm publish --access public
-        env:
-          NPM_CONFIG_PROVENANCE: true
-
-      - name: Publish unscoped tallow mirror
-        run: |
-          node -e "
-            const p = require('./package.json');
-            p.name = 'tallow';
-            require('fs').writeFileSync('package.json', JSON.stringify(p, null, '\t') + '\n');
-          "
-          npm publish --access public
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ships with 51 extensions, 34 themes, and 10 specialized agents.
 ## Quick start
 
 ```bash
-npm install -g tallow   # or: pnpm add -g tallow / bun install -g tallow
+npm install -g @dungle-scrubs/tallow
 tallow install          # pick extensions, themes, agents
 tallow                  # start coding
 ```

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ Install the CLI with your package manager, then run the installer once to
 create `~/.tallow/` and choose extensions and themes:
 
 ```bash
-bun install -g tallow
+npm install -g @dungle-scrubs/tallow
 tallow install
 ```
 
@@ -92,7 +92,7 @@ Updating tallow has two separate parts:
 
 ```bash
 # Global install
-bun install -g tallow@latest
+npm install -g @dungle-scrubs/tallow@latest
 
 # From source
 cd /path/to/tallow


### PR DESCRIPTION
## Summary

The unscoped `tallow` npm package can't be published via OIDC (E404 on PUT). Abandoning dual-publish in favor of the scoped `@dungle-scrubs/tallow` package.

## Changes

- **`.github/workflows/release.yml`** — reverted dual-publish step back to single publish
- **`README.md`** — install command now uses `npm install -g @dungle-scrubs/tallow`
- **`docs/.../installation.md`** — all install/upgrade commands use `@dungle-scrubs/tallow`

## npm side

All old `tallow@0.1.0–0.7.7` versions deprecated with message: "This package has moved to @dungle-scrubs/tallow"