### PR TITLE
fix(hooks): translate Claude event names in package and extension hooks

### DIFF
--- a/extensions/__integration__/claude-hooks-compat.test.ts
+++ b/extensions/__integration__/claude-hooks-compat.test.ts
@@ -192,3 +192,159 @@ describe("Claude hooks compatibility integration", () => {
 		expect(handlers).not.toContain("echo project-claude");
 	});
 });
+
+describe("Package hooks with Claude format", () => {
+	it("translates Claude event names in package hooks.json", () => {
+		const pkgDir = join(cwd, "my-package");
+		writeJson(join(pkgDir, "hooks.json"), {
+			PreToolUse: [
+				{
+					matcher: "Bash",
+					hooks: [{ type: "command", command: "echo pkg-pre" }],
+				},
+			],
+			Stop: [
+				{
+					hooks: [{ type: "command", command: "echo pkg-stop" }],
+				},
+			],
+		});
+
+		writeJson(join(homeDir, ".tallow", "settings.json"), {
+			packages: [pkgDir],
+		});
+
+		const config = loadHooksConfig(cwd);
+		expect(config.tool_call).toHaveLength(1);
+		expect(config.tool_call[0]?.matcher).toBe("bash");
+		expect(config.tool_call[0]?.hooks[0]?.command).toBe("echo pkg-pre");
+		expect(config.tool_call[0]?.hooks[0]?._claudeSource).toBe(true);
+		expect(config.tool_call[0]?.hooks[0]?._claudeEventName).toBe("PreToolUse");
+		expect(config.agent_end).toHaveLength(1);
+		expect(config.agent_end[0]?.hooks[0]?.command).toBe("echo pkg-stop");
+	});
+
+	it("does not double-translate native tallow hooks in packages", () => {
+		const pkgDir = join(cwd, "native-package");
+		writeJson(join(pkgDir, "hooks.json"), {
+			tool_call: [
+				{
+					matcher: "bash",
+					hooks: [{ type: "command", command: "echo native" }],
+				},
+			],
+		});
+
+		writeJson(join(homeDir, ".tallow", "settings.json"), {
+			packages: [pkgDir],
+		});
+
+		const config = loadHooksConfig(cwd);
+		expect(config.tool_call).toHaveLength(1);
+		expect(config.tool_call[0]?.matcher).toBe("bash");
+		expect(config.tool_call[0]?.hooks[0]?.command).toBe("echo native");
+		expect(config.tool_call[0]?.hooks[0]?._claudeSource).toBeUndefined();
+	});
+
+	it("handles mixed Claude and native events in a package hooks.json", () => {
+		const pkgDir = join(cwd, "mixed-package");
+		writeJson(join(pkgDir, "hooks.json"), {
+			PreToolUse: [
+				{
+					matcher: "Edit|Write",
+					hooks: [{ type: "command", command: "echo claude-pre" }],
+				},
+			],
+			tool_call: [
+				{
+					matcher: "bash",
+					hooks: [{ type: "command", command: "echo native-tool" }],
+				},
+			],
+		});
+
+		writeJson(join(homeDir, ".tallow", "settings.json"), {
+			packages: [pkgDir],
+		});
+
+		const config = loadHooksConfig(cwd);
+		expect(config.tool_call).toHaveLength(2);
+		const commands = config.tool_call.map((entry) => entry.hooks[0]?.command);
+		expect(commands).toContain("echo claude-pre");
+		expect(commands).toContain("echo native-tool");
+	});
+
+	it("translates Claude hooks from project-level package settings", () => {
+		const pkgDir = join(cwd, "proj-pkg");
+		writeJson(join(pkgDir, "hooks.json"), {
+			UserPromptSubmit: [
+				{
+					hooks: [{ type: "command", command: "echo proj-input" }],
+				},
+			],
+		});
+
+		writeJson(join(cwd, ".tallow", "settings.json"), {
+			packages: [pkgDir],
+		});
+
+		const config = loadHooksConfig(cwd);
+		expect(config.input).toHaveLength(1);
+		expect(config.input[0]?.hooks[0]?.command).toBe("echo proj-input");
+		expect(config.input[0]?.hooks[0]?._claudeEventName).toBe("UserPromptSubmit");
+	});
+
+	it("blocks untrusted project package hooks with Claude format", () => {
+		const pkgDir = join(cwd, "untrusted-pkg");
+		writeJson(join(pkgDir, "hooks.json"), {
+			PreToolUse: [
+				{
+					matcher: "Bash",
+					hooks: [{ type: "command", command: "echo untrusted" }],
+				},
+			],
+		});
+
+		writeJson(join(cwd, ".tallow", "settings.json"), {
+			packages: [pkgDir],
+		});
+
+		process.env.TALLOW_PROJECT_TRUST_STATUS = "untrusted";
+		const config = loadHooksConfig(cwd);
+		expect(config.tool_call ?? []).toHaveLength(0);
+	});
+});
+
+describe("Extension hooks with Claude format", () => {
+	it("translates Claude event names in extension hooks.json", () => {
+		writeJson(join(homeDir, ".tallow", "extensions", "my-ext", "hooks.json"), {
+			PreToolUse: [
+				{
+					matcher: "Bash",
+					hooks: [{ type: "command", command: "echo ext-pre" }],
+				},
+			],
+		});
+
+		const config = loadHooksConfig(cwd);
+		expect(config.tool_call).toHaveLength(1);
+		expect(config.tool_call[0]?.matcher).toBe("bash");
+		expect(config.tool_call[0]?.hooks[0]?._claudeSource).toBe(true);
+	});
+
+	it("translates Claude hooks in project extension hooks.json", () => {
+		writeJson(join(cwd, ".tallow", "extensions", "proj-ext", "hooks.json"), {
+			PostToolUse: [
+				{
+					matcher: "Write",
+					hooks: [{ type: "command", command: "echo proj-ext-post" }],
+				},
+			],
+		});
+
+		const config = loadHooksConfig(cwd);
+		expect(config.tool_result).toHaveLength(1);
+		expect(config.tool_result[0]?.matcher).toBe("write");
+		expect(config.tool_result[0]?.hooks[0]?._claudeEventName).toBe("PostToolUse");
+	});
+});

--- a/extensions/hooks/__tests__/claude-compat.test.ts
+++ b/extensions/hooks/__tests__/claude-compat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	adaptEventDataForHook,
 	CLAUDE_EVENT_MAP,
+	hasClaudeEventKeys,
 	shouldSkipClaudeToolResultHandler,
 	translateClaudeHooks,
 	translateClaudeOutput,
@@ -242,5 +243,39 @@ describe("shouldSkipClaudeToolResultHandler", () => {
 		expect(shouldSkipClaudeToolResultHandler("tool_result", { isError: false }, handler)).toBe(
 			false
 		);
+	});
+});
+
+describe("hasClaudeEventKeys", () => {
+	it("detects PreToolUse as a Claude event key", () => {
+		expect(hasClaudeEventKeys({ PreToolUse: [] })).toBe(true);
+	});
+
+	it("detects UserPromptSubmit as a Claude event key", () => {
+		expect(hasClaudeEventKeys({ UserPromptSubmit: [] })).toBe(true);
+	});
+
+	it("detects Stop as a Claude event key", () => {
+		expect(hasClaudeEventKeys({ Stop: [] })).toBe(true);
+	});
+
+	it("detects multiple Claude event keys", () => {
+		expect(hasClaudeEventKeys({ PreToolUse: [], PostToolUse: [], Stop: [] })).toBe(true);
+	});
+
+	it("returns false for native tallow event keys", () => {
+		expect(hasClaudeEventKeys({ tool_call: [], tool_result: [], agent_end: [] })).toBe(false);
+	});
+
+	it("returns false for empty objects", () => {
+		expect(hasClaudeEventKeys({})).toBe(false);
+	});
+
+	it("returns false for unrelated keys", () => {
+		expect(hasClaudeEventKeys({ name: "test", version: "1.0" })).toBe(false);
+	});
+
+	it("detects Claude keys in a mixed config", () => {
+		expect(hasClaudeEventKeys({ tool_call: [], PreToolUse: [] })).toBe(true);
 	});
 });

--- a/extensions/hooks/__tests__/subprocess-hardening.test.ts
+++ b/extensions/hooks/__tests__/subprocess-hardening.test.ts
@@ -119,3 +119,76 @@ describe("hook subprocess hardening", () => {
 		expect(elapsedMs).toBeLessThan(1000);
 	});
 });
+
+describe("Claude-sourced hook subprocess execution", () => {
+	/**
+	 * Build a Claude-sourced command hook handler.
+	 *
+	 * @param command - Shell command executed by the hook
+	 * @param claudeEventName - Original Claude event name
+	 * @returns Claude-sourced command-type hook handler
+	 */
+	function createClaudeHandler(command: string, claudeEventName: string): HookHandler {
+		return {
+			command,
+			timeout: 5,
+			type: "command",
+			_claudeSource: true,
+			_claudeEventName: claudeEventName,
+		};
+	}
+
+	test("Claude-sourced handler translates deny output to block result", async () => {
+		const handler = createClaudeHandler(
+			`node -e "process.stdout.write(JSON.stringify({hookSpecificOutput:{permissionDecision:'deny',permissionDecisionReason:'blocked by policy'}}))"`,
+			"PreToolUse"
+		);
+		const result = await runCommandHook(handler, { tool_name: "bash" }, process.cwd());
+
+		expect(result.ok).toBe(false);
+		expect(result.decision).toBe("block");
+		expect(result.reason).toBe("blocked by policy");
+	});
+
+	test("Claude-sourced handler translates additionalContext output", async () => {
+		const handler = createClaudeHandler(
+			`node -e "process.stdout.write(JSON.stringify({hookSpecificOutput:{additionalContext:'remember this context'}}))"`,
+			"UserPromptSubmit"
+		);
+		const result = await runCommandHook(handler, { prompt: "hello" }, process.cwd());
+
+		expect(result.ok).toBe(true);
+		expect(result.additionalContext).toBe("remember this context");
+	});
+
+	test("Claude-sourced handler sets CLAUDE_PROJECT_DIR env var", async () => {
+		const handler = createClaudeHandler(
+			`node -e "process.stdout.write(JSON.stringify({hookSpecificOutput:{additionalContext:process.env.CLAUDE_PROJECT_DIR}}))"`,
+			"PreToolUse"
+		);
+		const testCwd = process.cwd();
+		const result = await runCommandHook(handler, { tool_name: "bash" }, testCwd);
+
+		expect(result.ok).toBe(true);
+		expect(result.additionalContext).toBe(testCwd);
+	});
+
+	test("Claude-sourced handler exit code 2 still blocks", async () => {
+		const handler = createClaudeHandler(
+			`node -e "process.stderr.write('BLOCKED: unsafe operation'); process.exit(2)"`,
+			"PreToolUse"
+		);
+		const result = await runCommandHook(handler, { tool_name: "bash" }, process.cwd());
+
+		expect(result.ok).toBe(false);
+		expect(result.decision).toBe("block");
+		expect(result.reason).toContain("BLOCKED: unsafe operation");
+	});
+
+	test("Claude-sourced handler with no output succeeds silently", async () => {
+		const handler = createClaudeHandler("true", "PreToolUse");
+		const result = await runCommandHook(handler, { tool_name: "bash" }, process.cwd());
+
+		expect(result.ok).toBe(true);
+	});
+});

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -568,15 +568,33 @@ function mergeHooks(target: HooksConfig, source: HooksConfig): void {
  * Reads hooks from a JSON file (standalone hooks.json or settings.json with hooks key).
  * Returns null if the file doesn't exist or can't be parsed.
  */
+/**
+ * Check whether a parsed object contains any Claude Code event names as top-level keys.
+ *
+ * Used to detect hooks.json files that use Claude format (PreToolUse, UserPromptSubmit, etc.)
+ * instead of native tallow format (tool_call, input, etc.).
+ *
+ * @param obj - Parsed JSON object to inspect
+ * @returns True when at least one key is a known Claude event name
+ */
+export function hasClaudeEventKeys(obj: Record<string, unknown>): boolean {
+	return Object.keys(obj).some((key) => key in CLAUDE_EVENT_MAP);
+}
+
 function readHooksFile(filePath: string): HooksConfig | null {
 	try {
 		if (!fs.existsSync(filePath)) return null;
 		const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
 		// Standalone hooks.json has event keys at top level.
 		// settings.json wraps them under a "hooks" key.
+		// Also detect Claude event names (PreToolUse, etc.) as valid top-level keys.
 		return (
 			content.hooks ??
-			(content.tool_call || content.tool_result || content.agent_end ? content : null)
+			(content.tool_call || content.tool_result || content.agent_end
+				? content
+				: hasClaudeEventKeys(content)
+					? content
+					: null)
 		);
 	} catch {
 		return null;
@@ -596,7 +614,10 @@ function scanExtensionHooks(extensionsDir: string): HooksConfig {
 			const hooksPath = path.join(extensionsDir, entry, "hooks.json");
 			const hooks = readHooksFile(hooksPath);
 			if (hooks) {
-				mergeHooks(merged, hooks);
+				mergeHooks(
+					merged,
+					hasClaudeEventKeys(hooks) ? translateClaudeHooks(hooks, hooksPath) : hooks
+				);
 			}
 		}
 	} catch {
@@ -655,7 +676,9 @@ function getPackageHooks(settingsPath: string): HooksConfig[] {
 			const hooksFile = path.join(resolved, "hooks.json");
 			const hooks = readHooksFile(hooksFile);
 			if (hooks) {
-				results.push(hooks);
+				// Translate Claude event names if present, so packages can use
+				// either native tallow format or Claude Code format in hooks.json.
+				results.push(hasClaudeEventKeys(hooks) ? translateClaudeHooks(hooks, hooksFile) : hooks);
 			}
 		}
 	} catch {


### PR DESCRIPTION
## Problem

Package and extension `hooks.json` files using Claude Code event names (`PreToolUse`, `UserPromptSubmit`, `Stop`, etc.) were silently dropped — hooks never fired.

This blocked using Claude Code plugin format in pi-packages, which matters for shared team plugins that use Claude's hook format.

## Root Cause

Two issues in `loadHooksConfig`:

1. **`readHooksFile()`** returned `null` for configs with only Claude event keys — it only checked for `tool_call`/`tool_result`/`agent_end` as valid top-level keys
2. **`getPackageHooks()` and `scanExtensionHooks()`** never called `translateClaudeHooks()` — translation only happened for `.claude/settings.json` sources (steps 8–9)

## Fix

- Add `hasClaudeEventKeys()` helper to detect Claude event names in parsed configs
- Extend `readHooksFile` to accept configs with Claude event keys
- Run `translateClaudeHooks` in `getPackageHooks` and `scanExtensionHooks` when Claude event keys are detected

## Tests

- **8** unit tests for `hasClaudeEventKeys`
- **7** integration tests for package/extension Claude-format hooks (including trust gating, mixed formats)
- **5** subprocess tests for `_claudeSource` handler execution (deny output, additionalContext, env vars, exit code 2)

## Docs Impact

No docs changes needed — the packages docs already describe hooks.json support. This fix makes the existing documented behavior actually work for Claude-format hooks.