### PR TITLE
fix(tasks): suppress duplicate background task widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **background-task-tool,tasks:** suppress the duplicate live background-task
+  widget when the shared tasks dashboard is active, keeping `Background Tasks`
+  as the single surface and stopping above-editor row jitter
 - **tui:** fix streaming ghost empty spaces caused by stale `maxLinesRendered`
   high-water mark, missing `extraLines > height` safety guard in the diff
   cleanup path, and viewport drift correction firing one render cycle late

--- a/docs/src/content/docs/extensions/background-task-tool.mdx
+++ b/docs/src/content/docs/extensions/background-task-tool.mdx
@@ -10,8 +10,10 @@ without blocking the agent conversation. The `bg_bash` tool
 returns a task ID immediately. Check output with `task_output`
 and status with `task_status` at any time.
 
-A status widget shows running background tasks. The `/bg` command
-lists and manages all active tasks.
+When the tasks extension is not active, background-task-tool shows
+its own live widget for running commands. When tasks is active,
+running commands move into the shared `Background Tasks` section
+there instead. The `/bg` command lists and manages all active tasks.
 
 <Gallery images={[
   { src: "/screenshots/extensions/background-tasks/single-task.png", alt: "Single background task with status widget" },
@@ -23,14 +25,18 @@ lists and manages all active tasks.
 ### [tasks](/extensions/tasks/)
 
 Background bash tasks appear in the [tasks](/extensions/tasks/)
-widget alongside the task board and running agents. Each
+widget alongside the task board and running agents. When that
+shared widget is active, it becomes the canonical background-task
+surface and background-task-tool suppresses its standalone live
+widget to avoid duplicate rows and reorder jitter. Each
 background task shows the truncated command string and elapsed
 duration, capped at 5 visible entries with overflow.
 
 In the combined widget, background tasks render below agents
 with a spacer line. On wide terminals they share the right
-column; on narrow terminals they stack at the bottom. See
-[tasks, responsive layout](/extensions/tasks/#responsive-layout)
+column; on narrow terminals they stack at the bottom. Use
+`task_output(...)` when you want the full inline output for a
+specific task. See [tasks, responsive layout](/extensions/tasks/#responsive-layout)
 for the full layout behavior.
 
 ### [subagent](/extensions/subagent-tool/)

--- a/docs/src/content/docs/extensions/tasks.mdx
+++ b/docs/src/content/docs/extensions/tasks.mdx
@@ -101,9 +101,13 @@ to match the agent's identity in the task widget.
 ### [background-tasks](/extensions/background-task-tool/)
 
 Running background bash commands appear in the same widget,
-below the background subagent section. Each shows the truncated
-command string and elapsed duration. The widget caps at 5 visible
-background tasks with an overflow indicator.
+below the background subagent section. When the tasks widget is
+visible, it is the canonical background-task surface and
+background-task-tool suppresses its separate live tail widget.
+Each row shows the truncated command string and elapsed duration.
+The widget caps at 5 visible background tasks with an overflow
+indicator. Use `task_output(...)` when you want the full inline
+output for a specific task.
 
 ### [custom-footer](/extensions/custom-footer/)
 

--- a/extensions/__integration__/background-task-widget-ownership.test.ts
+++ b/extensions/__integration__/background-task-widget-ownership.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { ExtensionHarness } from "../../test-utils/extension-harness.js";
+import backgroundTasksExtension, {
+	setBackgroundTaskSpawnForTests,
+} from "../background-task-tool/index.js";
+import { registerTasksExtension } from "../tasks/commands/register-tasks-extension.js";
+import { TaskListStore } from "../tasks/state/index.js";
+
+const ORIGINAL_PI_IS_SUBAGENT = process.env.PI_IS_SUBAGENT;
+const ORIGINAL_PI_TEAM_NAME = process.env.PI_TEAM_NAME;
+
+interface CapturedWidget {
+	render: ((width: number) => string[]) | null;
+}
+
+interface WidgetCapture {
+	widgets: Map<string, CapturedWidget>;
+}
+
+/**
+ * Build an interactive-mode-like context that captures widgets by key.
+ *
+ * @param captured - Mutable widget capture registry
+ * @returns Extension context for event and tool execution
+ */
+function createContext(captured: WidgetCapture): ExtensionContext {
+	const theme = {
+		bold: (text: string) => text,
+		fg: (_color: unknown, text: string) => text,
+		strikethrough: (text: string) => text,
+	} as ExtensionContext["ui"]["theme"];
+
+	return {
+		ui: {
+			async confirm() {
+				return false;
+			},
+			async custom() {
+				return undefined as never;
+			},
+			async editor() {
+				return undefined;
+			},
+			get theme() {
+				return theme;
+			},
+			getAllThemes() {
+				return [];
+			},
+			getEditorText() {
+				return "";
+			},
+			getTheme() {
+				return undefined;
+			},
+			getToolsExpanded() {
+				return false;
+			},
+			async input() {
+				return undefined;
+			},
+			notify() {},
+			pasteToEditor() {},
+			async select() {
+				return undefined;
+			},
+			setEditorComponent() {},
+			setEditorText() {},
+			setFooter() {},
+			setHeader() {},
+			setStatus() {},
+			setTheme() {
+				return { success: false, error: "Test stub" };
+			},
+			setTitle() {},
+			setToolsExpanded() {},
+			setWidget(name, widget) {
+				if (!widget) {
+					captured.widgets.delete(name);
+					return;
+				}
+				if (Array.isArray(widget)) {
+					captured.widgets.set(name, {
+						render: () => widget,
+					});
+					return;
+				}
+				const component = widget(undefined as never, undefined as never);
+				captured.widgets.set(name, {
+					render: (width) => component.render(width),
+				});
+			},
+			setWorkingMessage() {},
+		} as ExtensionContext["ui"],
+		hasUI: true,
+		cwd: process.cwd(),
+		sessionManager: {
+			appendEntry: () => {},
+			getEntries: () => [],
+		} as never,
+		modelRegistry: {
+			getApiKeyForProvider: async () => undefined,
+		} as never,
+		model: undefined,
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	};
+}
+
+/**
+ * Read a registered tool by name.
+ *
+ * @param harness - Extension harness instance
+ * @param name - Tool name to resolve
+ * @returns Registered tool definition
+ */
+function getTool(harness: ExtensionHarness, name: string): ToolDefinition {
+	const tool = harness.tools.get(name);
+	if (!tool) throw new Error(`Expected tool "${name}" to be registered`);
+	return tool;
+}
+
+/**
+ * Execute a tool with the widget-capturing context.
+ *
+ * @param ctx - Extension execution context
+ * @param tool - Tool definition to execute
+ * @param params - Tool parameters
+ * @returns Tool result payload
+ */
+async function execTool(
+	ctx: ExtensionContext,
+	tool: ToolDefinition,
+	params: Record<string, unknown>
+): Promise<{ details: Record<string, unknown> }> {
+	return (await tool.execute("test-tool-call", params as never, undefined, undefined, ctx)) as {
+		details: Record<string, unknown>;
+	};
+}
+
+/**
+ * Render a captured widget to plain text.
+ *
+ * @param captured - Widget capture registry
+ * @param name - Widget key
+ * @param width - Terminal width to render at
+ * @returns Joined widget text
+ */
+function renderWidget(captured: WidgetCapture, name: string, width: number): string {
+	const widget = captured.widgets.get(name);
+	if (!widget?.render) throw new Error(`Expected widget "${name}" to be captured`);
+	return widget.render(width).join("\n");
+}
+
+beforeEach(() => {
+	process.env.PI_IS_SUBAGENT = "0";
+	delete process.env.PI_TEAM_NAME;
+	setBackgroundTaskSpawnForTests(undefined);
+});
+
+afterEach(() => {
+	setBackgroundTaskSpawnForTests(undefined);
+	if (ORIGINAL_PI_IS_SUBAGENT === undefined) delete process.env.PI_IS_SUBAGENT;
+	else process.env.PI_IS_SUBAGENT = ORIGINAL_PI_IS_SUBAGENT;
+	if (ORIGINAL_PI_TEAM_NAME === undefined) delete process.env.PI_TEAM_NAME;
+	else process.env.PI_TEAM_NAME = ORIGINAL_PI_TEAM_NAME;
+});
+
+describe("background task widget ownership", () => {
+	it("keeps the standalone bg-tasks widget when tasks is not registered", async () => {
+		const harness = ExtensionHarness.create();
+		const captured: WidgetCapture = { widgets: new Map() };
+		const ctx = createContext(captured);
+		backgroundTasksExtension(harness.api);
+
+		try {
+			await harness.fireEvent("session_start", {}, ctx);
+			const bgBash = getTool(harness, "bg_bash");
+			await execTool(ctx, bgBash, { command: "sleep 5" });
+
+			expect(captured.widgets.has("bg-tasks")).toBe(true);
+			expect(renderWidget(captured, "bg-tasks", 120)).toContain("sleep 5");
+		} finally {
+			await harness.fireEvent("session_shutdown", {}, ctx);
+			harness.reset();
+		}
+	});
+
+	it("suppresses the standalone widget when tasks owns background-task presentation", async () => {
+		const harness = ExtensionHarness.create();
+		const captured: WidgetCapture = { widgets: new Map() };
+		const ctx = createContext(captured);
+		backgroundTasksExtension(harness.api);
+		registerTasksExtension(harness.api, new TaskListStore(null), null);
+
+		try {
+			await harness.fireEvent("session_start", {}, ctx);
+			const bgBash = getTool(harness, "bg_bash");
+			await execTool(ctx, bgBash, { command: "sleep 5" });
+
+			expect(captured.widgets.has("bg-tasks")).toBe(false);
+			expect(captured.widgets.has("1-tasks")).toBe(true);
+			expect(renderWidget(captured, "1-tasks", 120)).toContain("Background Tasks (1)");
+			expect(renderWidget(captured, "1-tasks", 120)).toContain("sleep 5");
+		} finally {
+			await harness.fireEvent("session_shutdown", {}, ctx);
+			harness.reset();
+		}
+	});
+});

--- a/extensions/_shared/interop-events.ts
+++ b/extensions/_shared/interop-events.ts
@@ -7,6 +7,7 @@ export const INTEROP_EVENT_SCHEMA_VERSION = 1 as const;
 
 /** Event channels used for typed cross-extension state synchronization. */
 export const INTEROP_EVENT_NAMES = {
+	backgroundTasksPresenterState: "interop.v1.background-tasks.presenter-state",
 	backgroundTasksSnapshot: "interop.v1.background-tasks.snapshot",
 	stateRequest: "interop.v1.state.request",
 	subagentsSnapshot: "interop.v1.subagents.snapshot",
@@ -117,6 +118,10 @@ const InteropTeamViewSchema = Type.Object({
 });
 
 const InteropEventSchemas = {
+	[INTEROP_EVENT_NAMES.backgroundTasksPresenterState]: Type.Object({
+		active: Type.Boolean(),
+		schemaVersion: Type.Literal(INTEROP_EVENT_SCHEMA_VERSION),
+	}),
 	[INTEROP_EVENT_NAMES.backgroundTasksSnapshot]: Type.Object({
 		schemaVersion: Type.Literal(INTEROP_EVENT_SCHEMA_VERSION),
 		tasks: Type.Array(InteropBackgroundTaskViewSchema),

--- a/extensions/background-task-tool/index.ts
+++ b/extensions/background-task-tool/index.ts
@@ -8,7 +8,7 @@
  * - `task_output` tool: Retrieve output from a background task
  * - `task_status` tool: Check if a task is running or completed
  * - `/bg` command: List and manage background tasks
- * - Status widget shows running background tasks
+ * - Live widget shows running background tasks when the tasks extension is not presenting them
  *
  * Usage:
  *   Ask the agent to "run npm test in the background"
@@ -41,6 +41,7 @@ import {
 	INTEROP_EVENT_NAMES,
 	type InteropBackgroundTaskView,
 	onInteropEvent,
+	requestInteropState,
 } from "../_shared/interop-events.js";
 import { registerPid, unregisterPid } from "../_shared/pid-registry.js";
 import {
@@ -132,6 +133,8 @@ let tuiRef: TUI | null = null;
 // In-memory task registry (published via typed interop events)
 const tasks = new Map<string, BackgroundTask>();
 let taskCounter = 0;
+let backgroundTaskPresenterActive = false;
+let interopPresenterStateCleanup: (() => void) | undefined;
 let interopStateRequestCleanup: (() => void) | undefined;
 
 /** Shared mutable state for live-updating anchor components during consecutive polls. */
@@ -546,6 +549,21 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 	/** Maximum tail lines per task in the widget. */
 	const WIDGET_TAIL_LINES = 3;
 
+	/** Most recent UI context used for widget/status updates. */
+	let lastWidgetContext: ExtensionContext | null = null;
+
+	/**
+	 * Whether the tasks extension currently owns background-task presentation.
+	 *
+	 * When true, background-task-tool suppresses its duplicate live widget and
+	 * lets the tasks widget render the canonical summary row.
+	 *
+	 * @returns True when the tasks widget should be the only presenter
+	 */
+	function shouldSuppressTaskWidget(): boolean {
+		return backgroundTaskPresenterActive;
+	}
+
 	/**
 	 * Updates the status bar indicator for running background tasks.
 	 *
@@ -576,7 +594,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 
 		const running = [...tasks.values()].filter((t) => t.status === "running");
 
-		if (running.length === 0) {
+		if (running.length === 0 || shouldSuppressTaskWidget()) {
 			ctx.ui.setWidget("bg-tasks", undefined);
 			return;
 		}
@@ -624,10 +642,24 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 	 * @returns void
 	 */
 	function syncTaskState(ctx: ExtensionContext): void {
+		lastWidgetContext = ctx;
 		updateStatusBar(ctx);
 		updateTaskWidget(ctx);
 		publishBackgroundTaskSnapshot(pi.events);
 	}
+
+	interopPresenterStateCleanup?.();
+	interopPresenterStateCleanup = onInteropEvent(
+		pi.events,
+		INTEROP_EVENT_NAMES.backgroundTasksPresenterState,
+		(payload) => {
+			backgroundTaskPresenterActive = payload.active;
+			const currentContext = lastWidgetContext;
+			if (currentContext?.ui) {
+				updateTaskWidget(currentContext);
+			}
+		}
+	);
 
 	interopStateRequestCleanup?.();
 	interopStateRequestCleanup = onInteropEvent(pi.events, INTEROP_EVENT_NAMES.stateRequest, () => {
@@ -663,7 +695,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 		name: "bg_bash",
 		label: "bg_bash",
 		description:
-			"Run a bash command in the background. Returns immediately without blocking. Output streams to a bottom widget visible to the user.\n\nWHEN TO USE:\n- Starting daemons or servers\n- Long-running builds or tests\n- Any process you want to run independently\n\nThe command runs asynchronously. Use task_status/task_output to check results.\n\nWARNING: Never use bash tool with & to background processes - it will hang. Use bg_bash instead.",
+			"Run a bash command in the background. Returns immediately without blocking. When the tasks extension is active, progress appears in the Background Tasks widget; otherwise background-task-tool shows its own live widget.\n\nWHEN TO USE:\n- Starting daemons or servers\n- Long-running builds or tests\n- Any process you want to run independently\n\nThe command runs asynchronously. Use task_status/task_output to check results.\n\nWARNING: Never use bash tool with & to background processes - it will hang. Use bg_bash instead.",
 		parameters: Type.Object({
 			command: Type.String({
 				description: "Bash command to run in background",
@@ -1687,13 +1719,19 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 		promotedAbortControllers.clear();
 		pollStates.clear();
 		lastCompletedPoll = null;
+		backgroundTaskPresenterActive = false;
+		lastWidgetContext = null;
 		publishBackgroundTaskSnapshot(pi.events);
+		interopPresenterStateCleanup?.();
+		interopPresenterStateCleanup = undefined;
 		interopStateRequestCleanup?.();
 		interopStateRequestCleanup = undefined;
 	});
 
 	// Capture TUI reference and initialize on session start
 	pi.on("session_start", async (_event, ctx) => {
+		backgroundTaskPresenterActive = false;
+
 		// Capture TUI via a throwaway widget for requestRender access
 		ctx.ui.setWidget("bg-tasks-tui-capture", (tui, _theme) => {
 			tuiRef = tui;
@@ -1703,6 +1741,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 
 		ctx.ui.setStatus("bg-tasks", undefined);
 		syncTaskState(ctx);
+		requestInteropState(pi.events, "background-task-tool");
 	});
 
 	// Register Ctrl+Shift+B shortcut for background tasks

--- a/extensions/tasks/commands/register-tasks-extension.ts
+++ b/extensions/tasks/commands/register-tasks-extension.ts
@@ -11,6 +11,7 @@ import { Key, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { getIcon, getSpinner } from "../../_icons/index.js";
 import {
+	emitInteropEvent,
 	INTEROP_EVENT_NAMES,
 	onInteropEvent,
 	requestInteropState,
@@ -106,6 +107,7 @@ export function registerTasksExtension(
 	let backgroundTasks: BgTaskView[] = [];
 	let activeTeams: TeamWidgetView[] = [];
 	let teamDashboardActive = false;
+	let lastBackgroundTaskPresenterState: boolean | null = null;
 
 	if (tasksAnimationInterval) clearInterval(tasksAnimationInterval);
 	tasksAnimationInterval = undefined;
@@ -573,9 +575,39 @@ export function registerTasksExtension(
 		);
 	}
 
+	/**
+	 * Determine whether the tasks extension currently owns background-task
+	 * widget presentation.
+	 *
+	 * The tasks widget can safely suppress the standalone background-task-tool
+	 * widget whenever this main dashboard is visible and the team dashboard is
+	 * not active.
+	 *
+	 * @returns True when the tasks widget should be the canonical presenter
+	 */
+	function shouldPresentBackgroundTasks(): boolean {
+		return !isSubagent && state.visible && !teamDashboardActive;
+	}
+
+	/**
+	 * Publish background-task presenter ownership for background-task-tool.
+	 *
+	 * @returns void
+	 */
+	function publishBackgroundTaskPresenterState(): void {
+		const nextState = shouldPresentBackgroundTasks();
+		if (lastBackgroundTaskPresenterState === nextState) return;
+		lastBackgroundTaskPresenterState = nextState;
+		emitInteropEvent(pi.events, INTEROP_EVENT_NAMES.backgroundTasksPresenterState, {
+			active: nextState,
+		});
+	}
+
 	function updateWidget(ctx: ExtensionContext): void {
 		// Subagents have no UI — skip all widget rendering
 		if (isSubagent) return;
+
+		publishBackgroundTaskPresenterState();
 
 		// If every task is completed and the 2s completion window has passed,
 		// clear the list. This covers extension reloads where the original
@@ -1891,6 +1923,7 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 		backgroundTasks = [];
 		activeTeams = [];
 		teamDashboardActive = false;
+		lastBackgroundTaskPresenterState = null;
 		lastBgCount = 0;
 		lastBgTaskCount = 0;
 
@@ -1990,11 +2023,15 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 					updateWidget(ctx);
 				}
 			);
+			const unsubStateRequest = onInteropEvent(pi.events, INTEROP_EVENT_NAMES.stateRequest, () => {
+				publishBackgroundTaskPresenterState();
+			});
 			interopEventsCleanup = () => {
 				unsubSubagents();
 				unsubBackgroundTasks();
 				unsubTeams();
 				unsubDashboardState();
+				unsubStateRequest();
 			};
 
 			legacyInteropBridgeCleanup?.();
@@ -2098,6 +2135,10 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 
 	// Cleanup on session end
 	pi.on("session_shutdown", async () => {
+		emitInteropEvent(pi.events, INTEROP_EVENT_NAMES.backgroundTasksPresenterState, {
+			active: false,
+		});
+		lastBackgroundTaskPresenterState = false;
 		if (tasksAnimationInterval) {
 			clearInterval(tasksAnimationInterval);
 			tasksAnimationInterval = undefined;


### PR DESCRIPTION
## Summary
- suppress the duplicate `bg-tasks` live widget when the shared tasks dashboard is active
- keep standalone `background-task-tool` fallback behavior and add integration coverage for widget ownership
- update docs and changelog to describe the single-surface background task UI

## Testing
- bun test extensions/background-task-tool extensions/tasks extensions/__integration__/background-task-widget-ownership.test.ts
- bun run typecheck:extensions
- bun run test:docs
- `bun run lint` still fails on unrelated pre-existing issues in `src/__tests__/otel.test.ts` and `extensions/subagent-tool/process.ts`
