### PR TITLE
fix: repair model-invoked compact lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **slash-command-bridge:** move model-invoked `/compact` deferral to the
+  proven post-response `turn_end` boundary, add deterministic lifecycle
+  regression coverage, and stop stale `agent_end` races from dropping
+  compaction or resumption
 - **background-task-tool,tasks:** suppress the duplicate live background-task
   widget when the shared tasks dashboard is active, keeping `Background Tasks`
   as the single surface and stopping above-editor row jitter

--- a/docs/src/content/docs/extensions/slash-command-bridge.mdx
+++ b/docs/src/content/docs/extensions/slash-command-bridge.mdx
@@ -25,11 +25,17 @@ run_slash_command({ command: "context" })
 → "Context Usage: 45,000 / 200,000 tokens (22.5%)"
 
 run_slash_command({ command: "compact" })
-→ "Session compaction triggered."
+→ "Session compaction will begin after this response completes."
 ```
 
 If usage is unknown (`tokens: null`), `context` returns the same no-data error
 path as `/context` for parity.
+
+Model-invoked `compact` is deferred until the assistant finishes its current
+post-tool response. Once compaction actually completes, the bridge schedules a
+hidden continuation turn only if the session is still idle, which avoids the
+old dead-end where `/compact` returned successfully but no compaction or resume
+happened.
 
 ## Design
 

--- a/extensions/__integration__/slash-command-bridge.test.ts
+++ b/extensions/__integration__/slash-command-bridge.test.ts
@@ -1,22 +1,143 @@
 /**
- * Integration test for slash-command-bridge.
+ * Integration tests for slash-command-bridge.
  *
- * Verifies the tool works end-to-end via a session runner with a mock model
- * that invokes the run_slash_command tool.
+ * The compact regression uses the real headless session path and verifies the
+ * ordered lifecycle from tool result → deferred compact → resumed turn.
  */
 
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { ManualTimerScheduler } from "../../test-utils/manual-timer-scheduler.js";
 import { createScriptedStreamFn } from "../../test-utils/mock-model.js";
 import { createSessionRunner, type SessionRunner } from "../../test-utils/session-runner.js";
-import slashCommandBridge from "../slash-command-bridge/index.js";
+import slashCommandBridge, {
+	resetSlashCommandBridgeStateForTests,
+	setSlashCommandBridgeSchedulerForTests,
+} from "../slash-command-bridge/index.js";
+
+interface CompactionTrackerState {
+	order: string[];
+	resumedAssistantCount: number;
+}
 
 let runner: SessionRunner | undefined;
+let scheduler: ManualTimerScheduler;
+
+beforeEach(() => {
+	scheduler = new ManualTimerScheduler();
+	setSlashCommandBridgeSchedulerForTests(scheduler.runtime);
+});
 
 afterEach(() => {
 	runner?.dispose();
 	runner = undefined;
+	resetSlashCommandBridgeStateForTests();
 });
+
+/**
+ * Returns assistant text content as a plain string for matcher-friendly assertions.
+ *
+ * @param message - Agent message to inspect
+ * @returns Flattened text content
+ */
+function getMessageText(message: AgentMessage): string {
+	if (typeof message.content === "string") {
+		return message.content;
+	}
+
+	return message.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+/**
+ * Builds a tracking extension that records the compact lifecycle order.
+ *
+ * The hook also provides a deterministic compaction result so the regression can
+ * exercise the real deferred path without making a network summarization call.
+ *
+ * @param state - Shared mutable tracker state for assertions
+ * @returns Extension factory that records compact lifecycle events
+ */
+function buildCompactionTracker(state: CompactionTrackerState): ExtensionFactory {
+	return (pi: ExtensionAPI): void => {
+		pi.on("tool_result", async (event) => {
+			if (event.toolName !== "run_slash_command") {
+				return;
+			}
+			if ((event.details as { command?: string } | undefined)?.command !== "compact") {
+				return;
+			}
+			state.order.push("tool_result");
+		});
+
+		pi.on("turn_end", async (event) => {
+			if (event.message.role !== "assistant") {
+				return;
+			}
+			state.order.push(`turn_end:${event.message.stopReason}`);
+		});
+
+		pi.on("session_before_compact", async () => {
+			state.order.push("session_before_compact");
+			return {
+				compaction: {
+					summary: "mock compact summary",
+					firstKeptEntryId: undefined,
+					tokensBefore: 123,
+					details: { modifiedFiles: [], readFiles: [] },
+				},
+			};
+		});
+
+		pi.on("session_compact", async () => {
+			state.order.push("session_compact");
+		});
+
+		pi.on("message_end", async (event) => {
+			const text = getMessageText(event.message);
+			if (event.message.role === "custom" && text.includes("Session compaction is complete")) {
+				state.order.push("continuation_message");
+			}
+			if (event.message.role === "assistant" && text.includes("resumed after compact")) {
+				state.order.push("assistant_resumed");
+				state.resumedAssistantCount++;
+			}
+		});
+	};
+}
+
+/**
+ * Lets queued extension/session work settle after a prompt or timer advance.
+ *
+ * `session.prompt()` does not wait for all extension-side follow-up work, so the
+ * regression explicitly drains microtasks around `agent.waitForIdle()`.
+ *
+ * @param activeRunner - Runner whose session should be drained
+ * @returns Nothing
+ */
+async function flushSessionWork(activeRunner: SessionRunner): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await activeRunner.session.agent.waitForIdle();
+	await Promise.resolve();
+	await Promise.resolve();
+	await activeRunner.session.agent.waitForIdle();
+	await Promise.resolve();
+}
+
+/**
+ * Returns the first index of a recorded lifecycle step.
+ *
+ * @param order - Recorded lifecycle events
+ * @param step - Step name to locate
+ * @returns Zero-based index in the order array
+ */
+function indexOfStep(order: readonly string[], step: string): number {
+	return order.indexOf(step);
+}
 
 describe("slash-command-bridge integration", () => {
 	it("model invokes show-system-prompt and receives prompt text", async () => {
@@ -44,12 +165,11 @@ describe("slash-command-bridge integration", () => {
 		await runner.run("Show me the system prompt");
 
 		expect(toolResults).toHaveLength(1);
-		// System prompt exists and is non-empty in a real session
 		expect(toolResults[0].length).toBeGreaterThan(0);
 	});
 
 	it("model invokes context and receives usage data", async () => {
-		const toolResults: Array<{ text: string; isError: boolean }> = [];
+		const toolResults: Array<{ isError: boolean; text: string }> = [];
 
 		const tracker: ExtensionFactory = (pi: ExtensionAPI): void => {
 			pi.on("tool_result", async (event) => {
@@ -75,7 +195,6 @@ describe("slash-command-bridge integration", () => {
 		await runner.run("Check context usage");
 
 		expect(toolResults).toHaveLength(1);
-		// Context usage should contain token info (may be actual data or "no data" error)
 		expect(toolResults[0].text.length).toBeGreaterThan(0);
 	});
 
@@ -108,31 +227,58 @@ describe("slash-command-bridge integration", () => {
 		expect(toolResults[0]).toContain("reboot");
 	});
 
-	it("model invokes compact successfully", async () => {
-		const toolResults: string[] = [];
-
-		const tracker: ExtensionFactory = (pi: ExtensionAPI): void => {
-			pi.on("tool_result", async (event) => {
-				if (event.toolName === "run_slash_command") {
-					const text = event.content.find((c) => c.type === "text");
-					if (text?.type === "text") toolResults.push(text.text);
-				}
-			});
+	it("model-invoked compact preserves ordered lifecycle and resumes once", async () => {
+		const state: CompactionTrackerState = {
+			order: [],
+			resumedAssistantCount: 0,
 		};
 
 		runner = await createSessionRunner({
 			streamFn: createScriptedStreamFn([
+				{ text: "warmup" },
 				{
 					toolCalls: [{ name: "run_slash_command", arguments: { command: "compact" } }],
 				},
-				{ text: "Compaction started" },
+				{ text: "finish response" },
+				{ text: "resumed after compact" },
 			]),
-			extensionFactories: [slashCommandBridge, tracker],
+			extensionFactories: [slashCommandBridge, buildCompactionTracker(state)],
+			settings: {
+				compaction: {
+					enabled: true,
+					keepRecentTokens: 1,
+					reserveTokens: 10,
+				},
+			},
 		});
 
-		await runner.run("Compact the session");
+		await runner.run("warm up the session");
+		state.order.length = 0;
+		state.resumedAssistantCount = 0;
 
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0]).toContain("compaction will begin");
+		await runner.run("compact the session");
+		scheduler.advanceBy(200);
+		await flushSessionWork(runner);
+
+		expect(state.resumedAssistantCount).toBe(1);
+		expect(state.order.filter((step) => step === "session_before_compact")).toHaveLength(1);
+		expect(state.order.filter((step) => step === "session_compact")).toHaveLength(1);
+		expect(state.order.filter((step) => step === "assistant_resumed")).toHaveLength(1);
+
+		const toolResultIndex = indexOfStep(state.order, "tool_result");
+		const toolUseTurnEndIndex = indexOfStep(state.order, "turn_end:toolUse");
+		const finalTurnEndIndex = indexOfStep(state.order, "turn_end:stop");
+		const beforeCompactIndex = indexOfStep(state.order, "session_before_compact");
+		const compactIndex = indexOfStep(state.order, "session_compact");
+		const continuationIndex = indexOfStep(state.order, "continuation_message");
+		const resumedIndex = indexOfStep(state.order, "assistant_resumed");
+
+		expect(toolResultIndex).toBeGreaterThanOrEqual(0);
+		expect(toolUseTurnEndIndex).toBeGreaterThan(toolResultIndex);
+		expect(finalTurnEndIndex).toBeGreaterThan(toolUseTurnEndIndex);
+		expect(beforeCompactIndex).toBeGreaterThan(finalTurnEndIndex);
+		expect(compactIndex).toBeGreaterThan(beforeCompactIndex);
+		expect(continuationIndex).toBeGreaterThan(compactIndex);
+		expect(resumedIndex).toBeGreaterThan(continuationIndex);
 	});
 });

--- a/extensions/slash-command-bridge/__tests__/slash-command-bridge.test.ts
+++ b/extensions/slash-command-bridge/__tests__/slash-command-bridge.test.ts
@@ -1,824 +1,52 @@
 /**
  * Unit tests for the slash-command-bridge extension.
  *
- * Uses ExtensionHarness for isolated testing of tool registration,
- * command dispatch, context injection, and error handling.
+ * Focuses on compact deferral, chosen lifecycle boundary, exactly-once guards,
+ * and deterministic timer-driven continuation behavior.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { ContextUsage, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { AssistantMessage, ToolResultMessage, Usage } from "@mariozechner/pi-ai";
+import type {
+	ContextUsage,
+	ExtensionContext,
+	ExtensionUIContext,
+	TurnEndEvent,
+} from "@mariozechner/pi-coding-agent";
 import { ExtensionHarness } from "../../../test-utils/extension-harness.js";
-import slashCommandBridge from "../index.js";
+import { ManualTimerScheduler } from "../../../test-utils/manual-timer-scheduler.js";
+import slashCommandBridge, {
+	resetSlashCommandBridgeStateForTests,
+	setSlashCommandBridgeSchedulerForTests,
+} from "../index.js";
 
-// ── Setup ────────────────────────────────────────────────────────────────────
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
 
 let harness: ExtensionHarness;
+let scheduler: ManualTimerScheduler;
 
 beforeEach(async () => {
+	scheduler = new ManualTimerScheduler();
+	setSlashCommandBridgeSchedulerForTests(scheduler.runtime);
 	harness = ExtensionHarness.create();
 	await harness.loadExtension(slashCommandBridge);
 });
 
-afterEach(async () => {
-	await harness.fireEvent("session_before_switch", {
-		type: "session_before_switch",
-		reason: "switch",
-	});
+afterEach(() => {
+	resetSlashCommandBridgeStateForTests();
 });
-
-// ── Registration ─────────────────────────────────────────────────────────────
-
-describe("registration", () => {
-	test("registers run_slash_command tool", () => {
-		expect(harness.tools.has("run_slash_command")).toBe(true);
-	});
-
-	test("tool has correct label", () => {
-		const tool = harness.tools.get("run_slash_command");
-		expect(tool?.label).toBe("run_slash_command");
-	});
-
-	test("tool description lists available commands", () => {
-		const tool = harness.tools.get("run_slash_command");
-		expect(tool?.description).toContain("show-system-prompt");
-		expect(tool?.description).toContain("context");
-		expect(tool?.description).toContain("compact");
-	});
-
-	test("registers before_agent_start handler", () => {
-		expect(harness.handlers.has("before_agent_start")).toBe(true);
-	});
-});
-
-// ── Command execution: show-system-prompt ────────────────────────────────────
-
-describe("show-system-prompt", () => {
-	test("returns the current system prompt", async () => {
-		const systemPrompt = "You are a helpful assistant with custom instructions.";
-		const ctx = buildContext({ getSystemPrompt: () => systemPrompt });
-
-		const result = await executeTool({ command: "show-system-prompt" }, ctx);
-
-		expect(result.content[0]).toEqual({ type: "text", text: systemPrompt });
-	});
-
-	test("includes prompt length in details", async () => {
-		const systemPrompt = "Short prompt.";
-		const ctx = buildContext({ getSystemPrompt: () => systemPrompt });
-
-		const result = await executeTool({ command: "show-system-prompt" }, ctx);
-
-		expect(result.details).toEqual({ command: "show-system-prompt", length: systemPrompt.length });
-	});
-
-	test("handles empty system prompt", async () => {
-		const ctx = buildContext({ getSystemPrompt: () => "" });
-
-		const result = await executeTool({ command: "show-system-prompt" }, ctx);
-
-		expect(result.content[0]).toEqual({ type: "text", text: "" });
-		expect(result.isError).toBeUndefined();
-	});
-});
-
-// ── Command execution: context ───────────────────────────────────────────────
-
-describe("context", () => {
-	test("returns formatted context usage", async () => {
-		const usage: ContextUsage = { tokens: 45000, contextWindow: 200000 };
-		const ctx = buildContext({ getContextUsage: () => usage });
-
-		const result = await executeTool({ command: "context" }, ctx);
-
-		const text = result.content[0];
-		expect(text).toBeDefined();
-		if (text?.type === "text") {
-			expect(text.text).toContain("45,000");
-			expect(text.text).toContain("200,000");
-			expect(text.text).toContain("22.5%");
-			expect(text.text).toContain("155,000"); // free tokens
-		}
-	});
-
-	test("includes token data in details", async () => {
-		const usage: ContextUsage = { tokens: 10000, contextWindow: 100000 };
-		const ctx = buildContext({ getContextUsage: () => usage });
-
-		const result = await executeTool({ command: "context" }, ctx);
-
-		expect(result.details).toEqual({
-			command: "context",
-			tokens: 10000,
-			contextWindow: 100000,
-		});
-	});
-
-	test("returns error when no usage data available", async () => {
-		const ctx = buildContext({ getContextUsage: () => undefined });
-
-		const result = await executeTool({ command: "context" }, ctx);
-
-		expect(result.isError).toBe(true);
-		const text = result.content[0];
-		if (text?.type === "text") {
-			expect(text.text).toContain("No context usage data");
-		}
-	});
-
-	test("returns no-usage error when token count is unknown", async () => {
-		const usage: ContextUsage = { tokens: null, contextWindow: 200000, percent: null };
-		const ctx = buildContext({ getContextUsage: () => usage });
-
-		const result = await executeTool({ command: "context" }, ctx);
-
-		expect(result.isError).toBe(true);
-		expect(result.details).toEqual({ command: "context", error: "no_usage_data" });
-		const text = result.content[0];
-		if (text?.type === "text") {
-			expect(text.text).toContain("No context usage data");
-			expect(text.text).not.toContain("0 / 200,000");
-			expect(text.text).not.toContain("0.0%");
-		}
-	});
-
-	test("handles zero context window gracefully", async () => {
-		const usage: ContextUsage = { tokens: 0, contextWindow: 0 };
-		const ctx = buildContext({ getContextUsage: () => usage });
-
-		const result = await executeTool({ command: "context" }, ctx);
-
-		expect(result.isError).toBeUndefined();
-	});
-});
-
-// ── Command execution: compact ───────────────────────────────────────────────
-
-describe("compact", () => {
-	test("does NOT call ctx.compact() immediately — defers to agent_end", async () => {
-		let compactCalled = false;
-		const ctx = buildContext({
-			compact: () => {
-				compactCalled = true;
-			},
-		});
-
-		await executeTool({ command: "compact" }, ctx);
-
-		expect(compactCalled).toBe(false);
-	});
-
-	test("returns message instructing model to finish response", async () => {
-		const ctx = buildContext({ compact: () => {} });
-
-		const result = await executeTool({ command: "compact" }, ctx);
-
-		expect(result.isError).toBeUndefined();
-		const text = result.content[0];
-		if (text?.type === "text") {
-			expect(text.text).toContain("compaction will begin after this response");
-			expect(text.text).toContain("Do NOT call any more tools");
-		}
-	});
-
-	test("includes command name in details", async () => {
-		const ctx = buildContext({ compact: () => {} });
-
-		const result = await executeTool({ command: "compact" }, ctx);
-
-		expect(result.details).toEqual({ command: "compact" });
-	});
-
-	test("agent_end hook triggers deferred compact with callbacks", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			compact: (options) => {
-				compactOptions = options;
-			},
-		});
-
-		// Tool sets the deferred flag
-		await executeTool({ command: "compact" }, toolCtx);
-
-		// agent_end fires — should trigger compact
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		expect(compactOptions).toBeDefined();
-		expect(typeof compactOptions?.onComplete).toBe("function");
-		expect(typeof compactOptions?.onError).toBe("function");
-
-		// Clean up compact progress interval to avoid cross-test leakage.
-		compactOptions?.onError?.();
-	});
-
-	test("agent_end hook starts compact heartbeat updates with elapsed status", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const workingMessages: Array<string | undefined> = [];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: (message?: string) => {
-					workingMessages.push(message);
-				},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		expect(workingMessages[0]).toBe("Compacting session…");
-		expect(statusUpdates[0]?.key).toBe("compact");
-		expect(statusUpdates[0]?.text).toContain("compacting · 0s");
-
-		await sleep(1100);
-
-		const hasElapsedUpdate = statusUpdates.some((update) =>
-			update.text?.includes("compacting · 1s")
-		);
-		expect(hasElapsedUpdate).toBe(true);
-
-		compactOptions?.onError?.();
-	});
-
-	test("onComplete stops compact heartbeat and transitions to resuming", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const workingMessages: Array<string | undefined> = [];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: (message?: string) => {
-					workingMessages.push(message);
-				},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => true,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-		await sleep(1100);
-
-		compactOptions?.onComplete?.();
-		expect(workingMessages.at(-1)).toBe("Resuming task…");
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: "⏳ resuming" });
-
-		const updatesAfterComplete = statusUpdates.length;
-		await sleep(1200);
-		expect(statusUpdates).toHaveLength(updatesAfterComplete);
-	});
-
-	test("onComplete sends continuation message when agent is idle and no queued messages", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => true,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		// Trigger onComplete and wait for the setTimeout(200) to fire
-		compactOptions?.onComplete?.();
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
-		expect(continuation).toBeDefined();
-		expect(continuation?.display).toBe(false);
-		expect(continuation?.options?.triggerTurn).toBe(true);
-		expect(continuation?.content).toContain("compaction is complete");
-	});
-
-	test("onComplete always schedules continuation even when compaction queue has messages", async () => {
-		// Previously, onComplete short-circuited when hasCompactionQueuedMessages()
-		// returned true. This caused orphaned session steering messages because the
-		// method's false positive (checking session steering too) prevented the
-		// continuation timer from firing. Now the timer always fires — safety nets
-		// (turn_start cancellation, isIdle() check) prevent duplicate prompts.
-		// See plan 160.
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: () => {},
-				// Even with hasCompactionQueuedMessages exposed, onComplete
-				// no longer checks it.
-				hasCompactionQueuedMessages: () => true,
-			} as unknown as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => true,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		compactOptions?.onComplete?.();
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		// Continuation fires regardless — safety nets prevent duplicates
-		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
-		expect(continuation).toBeDefined();
-		expect(continuation?.content).toContain("compaction is complete");
-	});
-
-	test("onComplete skips continuation and clears indicators when agent is not idle", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const workingMessages: Array<string | undefined> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: (message?: string) => {
-					workingMessages.push(message);
-				},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => false,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		compactOptions?.onComplete?.();
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
-		expect(continuation).toBeUndefined();
-
-		// When not idle, the !isIdle() branch clears indicators
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
-		expect(workingMessages.at(-1)).toBeUndefined();
-	});
-
-	test("onError stops compact heartbeat, clears status, and sends no continuation", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => true,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-		await sleep(1100);
-
-		compactOptions?.onError?.();
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
-
-		const updatesAfterError = statusUpdates.length;
-		await sleep(1200);
-		expect(statusUpdates).toHaveLength(updatesAfterError);
-
-		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
-		expect(continuation).toBeUndefined();
-	});
-
-	test("agent_end hook is a no-op when no compact is pending", async () => {
-		let compactCalled = false;
-		const ctx = buildContext({
-			compact: () => {
-				compactCalled = true;
-			},
-		});
-
-		// Fire agent_end without a preceding compact tool call
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, ctx);
-
-		expect(compactCalled).toBe(false);
-	});
-
-	test("turn_start cancels continuation timer before it fires", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: () => {},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => true,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		// Trigger onComplete — starts the 200ms timer
-		compactOptions?.onComplete?.();
-
-		// Fire turn_start before the timer expires (simulates flushCompactionQueue
-		// prompting the agent first)
-		const turnCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: () => {},
-			} as ExtensionContext["ui"],
-		});
-		await harness.fireEvent("turn_start", { type: "turn_start" }, turnCtx);
-
-		// Wait longer than the 200ms timeout
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		// Timer was cancelled — no duplicate continuation message sent
-		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
-		expect(continuation).toBeUndefined();
-	});
-
-	test("turn_start clears footer status when resuming after compact", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-		compactOptions?.onComplete?.();
-
-		// Resuming status should be set
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: "⏳ resuming" });
-
-		// turn_start fires — should clear the footer status
-		const turnCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-		});
-		await harness.fireEvent("turn_start", { type: "turn_start" }, turnCtx);
-
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
-	});
-
-	test("turn_start is a no-op when not resuming after compact", async () => {
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const turnCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-		});
-
-		// Fire turn_start without any preceding compaction
-		await harness.fireEvent("turn_start", { type: "turn_start" }, turnCtx);
-
-		// No status updates should have been made
-		expect(statusUpdates).toHaveLength(0);
-	});
-
-	test("session_before_switch clears active compact heartbeat state", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-		await sleep(1100);
-
-		expect(compactOptions).toBeDefined();
-		expect(statusUpdates.some((update) => update.text?.includes("compacting"))).toBe(true);
-
-		const switchCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-		});
-		await harness.fireEvent(
-			"session_before_switch",
-			{ type: "session_before_switch", reason: "switch" },
-			switchCtx
-		);
-
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
-
-		const updatesAfterSwitch = statusUpdates.length;
-		await sleep(1200);
-		expect(statusUpdates).toHaveLength(updatesAfterSwitch);
-	});
-
-	test("session_before_switch clears resuming state and footer status", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-		compactOptions?.onComplete?.();
-
-		// Resuming status should be set
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: "⏳ resuming" });
-
-		// Session switch fires — should clear resuming state
-		const switchCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: (key: string, text?: string) => {
-					statusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-		});
-		await harness.fireEvent(
-			"session_before_switch",
-			{ type: "session_before_switch", reason: "switch" },
-			switchCtx
-		);
-
-		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
-
-		// Subsequent turn_start should be a no-op (flag was cleared)
-		const turnStatusUpdates: Array<{ key: string; text: string | undefined }> = [];
-		const turnCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: (key: string, text?: string) => {
-					turnStatusUpdates.push({ key, text });
-				},
-			} as ExtensionContext["ui"],
-		});
-		await harness.fireEvent("turn_start", { type: "turn_start" }, turnCtx);
-
-		expect(turnStatusUpdates).toHaveLength(0);
-	});
-
-	test("session_before_switch cancels continuation timer", async () => {
-		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setWorkingMessage: () => {},
-				setStatus: () => {},
-			} as ExtensionContext["ui"],
-			compact: (options) => {
-				compactOptions = options;
-			},
-			isIdle: () => true,
-		});
-
-		await executeTool({ command: "compact" }, toolCtx);
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		// Trigger onComplete — starts the 200ms timer
-		compactOptions?.onComplete?.();
-
-		// Session switch fires before timer expires
-		const switchCtx = buildContext({
-			hasUI: true,
-			ui: {
-				setStatus: () => {},
-			} as ExtensionContext["ui"],
-		});
-		await harness.fireEvent(
-			"session_before_switch",
-			{ type: "session_before_switch", reason: "switch" },
-			switchCtx
-		);
-
-		// Wait longer than the 200ms timeout
-		await new Promise((resolve) => setTimeout(resolve, 300));
-
-		// Timer was cancelled — no continuation message sent
-		const continuation = harness.sentMessages.find((m) => m.customType === "compact-continue");
-		expect(continuation).toBeUndefined();
-	});
-
-	test("repeated compact lifecycle does not leave duplicate heartbeat intervals", async () => {
-		const originalSetInterval = globalThis.setInterval;
-		const originalClearInterval = globalThis.clearInterval;
-		const createdHandles: unknown[] = [];
-		const clearedHandles: unknown[] = [];
-		let handleIndex = 0;
-
-		globalThis.setInterval = ((callback: Parameters<typeof setInterval>[0], _ms?: number) => {
-			void callback;
-			handleIndex += 1;
-			const handle = { id: handleIndex };
-			createdHandles.push(handle);
-			return handle as unknown as ReturnType<typeof setInterval>;
-		}) as typeof setInterval;
-		globalThis.clearInterval = ((handle?: ReturnType<typeof setInterval>) => {
-			clearedHandles.push(handle);
-		}) as typeof clearInterval;
-
-		try {
-			const toolCtx = buildContext({ compact: () => {} });
-			const agentEndCtx = buildContext({
-				hasUI: true,
-				ui: {
-					setWorkingMessage: () => {},
-					setStatus: () => {},
-				} as ExtensionContext["ui"],
-				compact: () => {},
-			});
-
-			await executeTool({ command: "compact" }, toolCtx);
-			await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-			await executeTool({ command: "compact" }, toolCtx);
-			await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-			await harness.fireEvent("session_before_switch", {
-				type: "session_before_switch",
-				reason: "switch",
-			});
-
-			expect(createdHandles).toHaveLength(2);
-			expect(clearedHandles).toContain(createdHandles[0]);
-			expect(clearedHandles).toContain(createdHandles[1]);
-		} finally {
-			globalThis.setInterval = originalSetInterval;
-			globalThis.clearInterval = originalClearInterval;
-		}
-	});
-
-	test("session_before_switch clears pending compact", async () => {
-		let compactCalled = false;
-		const toolCtx = buildContext({ compact: () => {} });
-		const agentEndCtx = buildContext({
-			compact: () => {
-				compactCalled = true;
-			},
-		});
-
-		// Set pending compact
-		await executeTool({ command: "compact" }, toolCtx);
-
-		// Session switch fires — should clear the flag
-		await harness.fireEvent("session_before_switch", {
-			type: "session_before_switch",
-			reason: "switch",
-		});
-
-		// agent_end should now be a no-op
-		await harness.fireEvent("agent_end", { type: "agent_end", messages: [] }, agentEndCtx);
-
-		expect(compactCalled).toBe(false);
-	});
-});
-
-// ── Error handling ───────────────────────────────────────────────────────────
-
-describe("error handling", () => {
-	test("rejects unknown commands", async () => {
-		const ctx = buildContext();
-
-		const result = await executeTool({ command: "nonexistent" }, ctx);
-
-		expect(result.isError).toBe(true);
-		const text = result.content[0];
-		if (text?.type === "text") {
-			expect(text.text).toContain("Unknown command");
-			expect(text.text).toContain("nonexistent");
-			expect(text.text).toContain("show-system-prompt");
-			expect(text.text).toContain("context");
-			expect(text.text).toContain("compact");
-		}
-	});
-
-	test("rejects commands with / prefix", async () => {
-		const ctx = buildContext();
-
-		const result = await executeTool({ command: "/compact" }, ctx);
-
-		expect(result.isError).toBe(true);
-	});
-
-	test("rejects empty command string", async () => {
-		const ctx = buildContext();
-
-		const result = await executeTool({ command: "" }, ctx);
-
-		expect(result.isError).toBe(true);
-	});
-});
-
-// ── Context injection ────────────────────────────────────────────────────────
-
-describe("context injection", () => {
-	test("injects hidden message listing bridged commands", async () => {
-		const results = await harness.fireEvent("before_agent_start", {
-			type: "before_agent_start",
-			prompt: "hello",
-			systemPrompt: "",
-		});
-
-		const result = results.find((r) => r != null) as
-			| {
-					message: { customType: string; content: string; display: boolean };
-			  }
-			| undefined;
-
-		expect(result).toBeDefined();
-		expect(result?.message.customType).toBe("slash-command-bridge-context");
-		expect(result?.message.display).toBe(false);
-		expect(result?.message.content).toContain("run_slash_command");
-	});
-
-	test("context message mentions available commands", async () => {
-		const results = await harness.fireEvent("before_agent_start", {
-			type: "before_agent_start",
-			prompt: "hello",
-			systemPrompt: "",
-		});
-
-		const result = results.find((r) => r != null) as
-			| {
-					message: { content: string };
-			  }
-			| undefined;
-
-		expect(result?.message.content).toContain("/show-system-prompt");
-		expect(result?.message.content).toContain("/context");
-		expect(result?.message.content).toContain("/compact");
-	});
-});
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Build a mock ExtensionContext with overridable methods.
+ * Builds a mock ExtensionContext with overridable methods.
  *
- * @param overrides - Methods to override on the default stub context
+ * @param overrides - Methods/properties to override on the default stub context
  * @returns Mock ExtensionContext
  */
 function buildContext(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
@@ -841,25 +69,384 @@ function buildContext(overrides: Partial<ExtensionContext> = {}): ExtensionConte
 }
 
 /**
- * Waits for a given number of milliseconds.
+ * Creates a realistic assistant turn_end event for compact lifecycle tests.
  *
- * @param milliseconds - Delay duration in milliseconds
- * @returns Promise that resolves after the delay
+ * @param stopReason - Assistant stop reason for the completed turn
+ * @returns TurnEnd event payload
  */
-function sleep(milliseconds: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+function buildAssistantTurnEnd(stopReason: AssistantMessage["stopReason"]): TurnEndEvent {
+	return {
+		type: "turn_end",
+		turnIndex: 0,
+		message: {
+			role: "assistant",
+			content: [],
+			api: "anthropic-messages",
+			provider: "mock",
+			model: "mock-model",
+			stopReason,
+			timestamp: Date.now(),
+			usage: { ...ZERO_USAGE },
+		},
+		toolResults: stopReason === "toolUse" ? [buildCompactToolResult()] : [],
+	};
 }
 
 /**
- * Execute the run_slash_command tool with the given params and context.
+ * Builds the compact tool result payload recorded on the tool-use turn.
+ *
+ * @returns Tool result message for `run_slash_command({ command: "compact" })`
+ */
+function buildCompactToolResult(): ToolResultMessage<{ command: string }> {
+	return {
+		role: "toolResult",
+		toolCallId: "mock-tool-call",
+		toolName: "run_slash_command",
+		content: [
+			{ type: "text", text: "Session compaction will begin after this response completes." },
+		],
+		details: { command: "compact" },
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Executes the registered slash-command tool with the provided context.
  *
  * @param params - Tool parameters
- * @param ctx - Extension context (optional, uses default stub)
+ * @param ctx - Extension context for the execution
  * @returns Tool execution result
  */
 async function executeTool(params: { command: string }, ctx?: ExtensionContext) {
 	const tool = harness.tools.get("run_slash_command");
-	if (!tool) throw new Error("run_slash_command tool not registered");
+	if (!tool) {
+		throw new Error("run_slash_command tool not registered");
+	}
 
 	return tool.execute("test-call-id", params, undefined, undefined, ctx ?? buildContext());
 }
+
+describe("registration", () => {
+	test("registers run_slash_command and lifecycle handlers", () => {
+		expect(harness.tools.has("run_slash_command")).toBe(true);
+		expect(harness.handlers.has("before_agent_start")).toBe(true);
+		expect(harness.handlers.has("turn_end")).toBe(true);
+		expect(harness.handlers.has("turn_start")).toBe(true);
+		expect(harness.handlers.has("session_before_switch")).toBe(true);
+	});
+});
+
+describe("show-system-prompt", () => {
+	test("returns the current system prompt", async () => {
+		const systemPrompt = "You are a helpful assistant with custom instructions.";
+		const ctx = buildContext({ getSystemPrompt: () => systemPrompt });
+
+		const result = await executeTool({ command: "show-system-prompt" }, ctx);
+
+		expect(result.content[0]).toEqual({ type: "text", text: systemPrompt });
+		expect(result.details).toEqual({ command: "show-system-prompt", length: systemPrompt.length });
+	});
+});
+
+describe("context", () => {
+	test("returns formatted context usage", async () => {
+		const usage: ContextUsage = { tokens: 45000, contextWindow: 200000 };
+		const ctx = buildContext({ getContextUsage: () => usage });
+
+		const result = await executeTool({ command: "context" }, ctx);
+		const text = result.content[0];
+
+		expect(text).toBeDefined();
+		if (text?.type === "text") {
+			expect(text.text).toContain("45,000");
+			expect(text.text).toContain("200,000");
+			expect(text.text).toContain("22.5%");
+		}
+	});
+
+	test("returns error when usage data is unavailable", async () => {
+		const result = await executeTool({ command: "context" }, buildContext());
+
+		expect(result.isError).toBe(true);
+		expect(result.details).toEqual({ command: "context", error: "no_usage_data" });
+	});
+});
+
+describe("error handling", () => {
+	test("rejects unknown commands", async () => {
+		const result = await executeTool({ command: "reboot" }, buildContext());
+
+		expect(result.isError).toBe(true);
+		const text = result.content[0];
+		if (text?.type === "text") {
+			expect(text.text).toContain("Unknown command");
+			expect(text.text).toContain("reboot");
+		}
+	});
+});
+
+describe("context injection", () => {
+	test("injects hidden context listing bridged commands", async () => {
+		const results = await harness.fireEvent("before_agent_start", {
+			type: "before_agent_start",
+			prompt: "hello",
+			systemPrompt: "",
+		});
+
+		const result = results.find((entry) => entry != null) as
+			| {
+					message: { content: string; customType: string; display: boolean };
+			  }
+			| undefined;
+
+		expect(result?.message.customType).toBe("slash-command-bridge-context");
+		expect(result?.message.display).toBe(false);
+		expect(result?.message.content).toContain("/show-system-prompt");
+		expect(result?.message.content).toContain("/context");
+		expect(result?.message.content).toContain("/compact");
+	});
+});
+
+describe("compact", () => {
+	test("defers compact instead of calling ctx.compact inline", async () => {
+		let compactCalled = false;
+		const ctx = buildContext({
+			compact: () => {
+				compactCalled = true;
+			},
+		});
+
+		const result = await executeTool({ command: "compact" }, ctx);
+
+		expect(compactCalled).toBe(false);
+		expect(result.details).toEqual({ command: "compact" });
+		const text = result.content[0];
+		if (text?.type === "text") {
+			expect(text.text).toContain("compaction will begin after this response");
+			expect(text.text).toContain("Do NOT call any more tools");
+		}
+	});
+
+	test("waits through the tool-use turn and compacts on the following assistant turn_end", async () => {
+		let compactCalls = 0;
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const ctx = buildContext({
+			compact: (options) => {
+				compactCalls++;
+				compactOptions = options;
+			},
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		expect(compactCalls).toBe(0);
+
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		expect(compactCalls).toBe(1);
+		expect(typeof compactOptions?.onComplete).toBe("function");
+		expect(typeof compactOptions?.onError).toBe("function");
+	});
+
+	test("consumes the pending request exactly once", async () => {
+		let compactCalls = 0;
+		const ctx = buildContext({
+			compact: () => {
+				compactCalls++;
+			},
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+
+		expect(compactCalls).toBe(1);
+	});
+
+	test("drives heartbeat and continuation timers deterministically", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
+		const workingMessages: Array<string | undefined> = [];
+		const ctx = buildContext({
+			hasUI: true,
+			ui: {
+				setStatus: (key: string, text?: string) => {
+					statusUpdates.push({ key, text });
+				},
+				setWorkingMessage: (message?: string) => {
+					workingMessages.push(message);
+				},
+			} as ExtensionUIContext,
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => true,
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+
+		expect(workingMessages[0]).toBe("Compacting session…");
+		expect(statusUpdates[0]).toEqual({ key: "compact", text: "🧹 ⠋ compacting · 0s" });
+
+		scheduler.advanceBy(1000);
+		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: "🧹 ⠙ compacting · 1s" });
+
+		compactOptions?.onComplete?.();
+		expect(workingMessages.at(-1)).toBe("Resuming task…");
+		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: "⏳ resuming" });
+
+		scheduler.advanceBy(199);
+		expect(harness.sentMessages).toHaveLength(0);
+		scheduler.advanceBy(1);
+
+		const continuation = harness.sentMessages.find(
+			(message) => message.customType === "compact-continue"
+		);
+		expect(continuation?.display).toBe(false);
+		expect(continuation?.options?.triggerTurn).toBe(true);
+		expect(continuation?.content).toContain("compaction is complete");
+	});
+
+	test("turn_start cancels the delayed continuation and clears the footer status", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
+		const ctx = buildContext({
+			hasUI: true,
+			ui: {
+				setStatus: (key: string, text?: string) => {
+					statusUpdates.push({ key, text });
+				},
+				setWorkingMessage: () => {},
+			} as ExtensionUIContext,
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => true,
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		compactOptions?.onComplete?.();
+
+		await harness.fireEvent("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 0 }, ctx);
+		scheduler.advanceBy(200);
+
+		expect(harness.sentMessages).toHaveLength(0);
+		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
+	});
+
+	test("skips continuation and clears indicators when the session is no longer idle", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
+		const workingMessages: Array<string | undefined> = [];
+		const ctx = buildContext({
+			hasUI: true,
+			ui: {
+				setStatus: (key: string, text?: string) => {
+					statusUpdates.push({ key, text });
+				},
+				setWorkingMessage: (message?: string) => {
+					workingMessages.push(message);
+				},
+			} as ExtensionUIContext,
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => false,
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		compactOptions?.onComplete?.();
+		scheduler.advanceBy(200);
+
+		expect(harness.sentMessages).toHaveLength(0);
+		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
+		expect(workingMessages.at(-1)).toBeUndefined();
+	});
+
+	test("onError clears compact UI and sends no continuation", async () => {
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
+		const workingMessages: Array<string | undefined> = [];
+		const ctx = buildContext({
+			hasUI: true,
+			ui: {
+				setStatus: (key: string, text?: string) => {
+					statusUpdates.push({ key, text });
+				},
+				setWorkingMessage: (message?: string) => {
+					workingMessages.push(message);
+				},
+			} as ExtensionUIContext,
+			compact: (options) => {
+				compactOptions = options;
+			},
+			isIdle: () => true,
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		scheduler.advanceBy(1000);
+		compactOptions?.onError?.(new Error("boom"));
+		scheduler.advanceBy(200);
+
+		expect(harness.sentMessages).toHaveLength(0);
+		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
+		expect(workingMessages.at(-1)).toBeUndefined();
+	});
+
+	test("session_before_switch clears pending compact, timers, and UI state", async () => {
+		let compactCalls = 0;
+		let compactOptions: Parameters<ExtensionContext["compact"]>[0];
+		const statusUpdates: Array<{ key: string; text: string | undefined }> = [];
+		const workingMessages: Array<string | undefined> = [];
+		const ctx = buildContext({
+			hasUI: true,
+			ui: {
+				setStatus: (key: string, text?: string) => {
+					statusUpdates.push({ key, text });
+				},
+				setWorkingMessage: (message?: string) => {
+					workingMessages.push(message);
+				},
+			} as ExtensionUIContext,
+			compact: (options) => {
+				compactCalls++;
+				compactOptions = options;
+			},
+			isIdle: () => true,
+		});
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent(
+			"session_before_switch",
+			{ type: "session_before_switch", reason: "switch" },
+			ctx
+		);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		expect(compactCalls).toBe(0);
+
+		await executeTool({ command: "compact" }, buildContext());
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("toolUse"), ctx);
+		await harness.fireEvent("turn_end", buildAssistantTurnEnd("stop"), ctx);
+		compactOptions?.onComplete?.();
+		await harness.fireEvent(
+			"session_before_switch",
+			{ type: "session_before_switch", reason: "switch" },
+			ctx
+		);
+		scheduler.advanceBy(200);
+
+		expect(harness.sentMessages).toHaveLength(0);
+		expect(statusUpdates.at(-1)).toEqual({ key: "compact", text: undefined });
+		expect(workingMessages.at(-1)).toBeUndefined();
+	});
+});

--- a/extensions/slash-command-bridge/extension.json
+++ b/extensions/slash-command-bridge/extension.json
@@ -5,7 +5,7 @@
 	"whenToUse": "Use when the model should invoke slash commands through a tool.",
 	"capabilities": {
 		"tools": ["run_slash_command"],
-		"events": ["agent_end", "before_agent_start", "session_before_switch"]
+		"events": ["before_agent_start", "session_before_switch", "turn_end", "turn_start"]
 	},
 	"permissionSurface": {
 		"filesystem": "none",

--- a/extensions/slash-command-bridge/index.ts
+++ b/extensions/slash-command-bridge/index.ts
@@ -9,15 +9,20 @@
  * registration, with auto-generated tool schemas and full command handler access.
  */
 
-import type { ContextUsage, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type {
+	ContextUsage,
+	ExtensionAPI,
+	ExtensionContext,
+	TurnEndEvent,
+} from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 
 /**
- * Deferred compact request — set by the tool handler, consumed by the
- * `agent_end` hook. Deferring avoids the spinner-hang bug where
- * `ctx.compact()` aborts the agent mid-tool-call, orphaning the tool
- * execution UI component. See plans 95 and 98 for full analysis.
+ * Deferred compact request — set by the tool handler, consumed on the first
+ * safe assistant `turn_end` after the tool result. Deferring avoids the
+ * spinner-hang bug where `ctx.compact()` aborts the agent mid-tool-call,
+ * orphaning the tool execution UI component. See plans 95, 98, and 191.
  */
 let pendingCompact: { customInstructions?: string } | null = null;
 
@@ -35,7 +40,7 @@ let resumingAfterCompact = false;
  * `flushCompactionQueue` or user input already prompted the agent), or
  * on session switch. See plan 159, bug 1.
  */
-let continuationTimer: ReturnType<typeof setTimeout> | null = null;
+let continuationTimer: SchedulerHandle | null = null;
 
 /** Spinner frames for compact progress status updates. */
 const COMPACT_PROGRESS_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -43,9 +48,39 @@ const COMPACT_PROGRESS_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦"
 /** Interval cadence for compact progress status updates. */
 const COMPACT_PROGRESS_INTERVAL_MS = 1000;
 
+type SchedulerHandle = unknown;
+
+/** Timer scheduler used by compact UI and continuation timers. */
+export interface SlashCommandBridgeTimerScheduler {
+	readonly now: () => number;
+	readonly setInterval: (callback: () => void, intervalMs: number) => SchedulerHandle;
+	readonly clearInterval: (handle: SchedulerHandle | null) => void;
+	readonly setTimeout: (callback: () => void, delayMs: number) => SchedulerHandle;
+	readonly clearTimeout: (handle: SchedulerHandle | null) => void;
+}
+
+/** Default runtime timer scheduler. */
+const DEFAULT_TIMER_SCHEDULER: SlashCommandBridgeTimerScheduler = {
+	now: () => Date.now(),
+	setInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
+	clearInterval: (handle) => {
+		if (handle) {
+			clearInterval(handle as ReturnType<typeof setInterval>);
+		}
+	},
+	setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+	clearTimeout: (handle) => {
+		if (handle) {
+			clearTimeout(handle as ReturnType<typeof setTimeout>);
+		}
+	},
+};
+
+let timerScheduler: SlashCommandBridgeTimerScheduler = DEFAULT_TIMER_SCHEDULER;
+
 /** Module-level heartbeat state for deferred compact UI updates. */
 const compactProgressState: {
-	interval: ReturnType<typeof setInterval> | null;
+	interval: SchedulerHandle | null;
 	spinnerIndex: number;
 	startedAt: number;
 } = {
@@ -70,11 +105,13 @@ function startCompactProgress(ctx: ExtensionContext): void {
 		return;
 	}
 
-	compactProgressState.startedAt = Date.now();
+	compactProgressState.startedAt = timerScheduler.now();
 	compactProgressState.spinnerIndex = 0;
 
 	const renderStatus = () => {
-		const elapsedSeconds = Math.floor((Date.now() - compactProgressState.startedAt) / 1000);
+		const elapsedSeconds = Math.floor(
+			(timerScheduler.now() - compactProgressState.startedAt) / 1000
+		);
 		const frame =
 			COMPACT_PROGRESS_FRAMES[compactProgressState.spinnerIndex] ?? COMPACT_PROGRESS_FRAMES[0];
 		ctx.ui?.setStatus?.("compact", `🧹 ${frame} compacting · ${elapsedSeconds}s`);
@@ -83,7 +120,10 @@ function startCompactProgress(ctx: ExtensionContext): void {
 	};
 
 	renderStatus();
-	compactProgressState.interval = setInterval(renderStatus, COMPACT_PROGRESS_INTERVAL_MS);
+	compactProgressState.interval = timerScheduler.setInterval(
+		renderStatus,
+		COMPACT_PROGRESS_INTERVAL_MS
+	);
 }
 
 /**
@@ -93,12 +133,61 @@ function startCompactProgress(ctx: ExtensionContext): void {
  */
 function stopCompactProgress(): void {
 	if (compactProgressState.interval) {
-		clearInterval(compactProgressState.interval);
+		timerScheduler.clearInterval(compactProgressState.interval);
 		compactProgressState.interval = null;
 	}
 
 	compactProgressState.startedAt = 0;
 	compactProgressState.spinnerIndex = 0;
+}
+
+/**
+ * Cancels the pending continuation timer, if one exists.
+ *
+ * @returns Nothing
+ */
+function clearContinuationTimer(): void {
+	if (!continuationTimer) {
+		return;
+	}
+
+	timerScheduler.clearTimeout(continuationTimer);
+	continuationTimer = null;
+}
+
+/**
+ * Resets module-level compact state between runs or tests.
+ *
+ * @returns Nothing
+ */
+function clearCompactRuntimeState(): void {
+	pendingCompact = null;
+	resumingAfterCompact = false;
+	stopCompactProgress();
+	clearContinuationTimer();
+}
+
+/**
+ * Installs a deterministic timer scheduler for tests.
+ *
+ * @param scheduler - Test scheduler implementation
+ * @returns Nothing
+ */
+export function setSlashCommandBridgeSchedulerForTests(
+	scheduler: SlashCommandBridgeTimerScheduler
+): void {
+	clearCompactRuntimeState();
+	timerScheduler = scheduler;
+}
+
+/**
+ * Resets test scheduler/state overrides back to runtime defaults.
+ *
+ * @returns Nothing
+ */
+export function resetSlashCommandBridgeStateForTests(): void {
+	clearCompactRuntimeState();
+	timerScheduler = DEFAULT_TIMER_SCHEDULER;
 }
 
 /**
@@ -175,6 +264,102 @@ function formatContextUsage(usage: KnownContextUsage): string {
 	];
 
 	return lines.join("\n");
+}
+
+/**
+ * Returns true when the current turn_end is the first safe compaction boundary.
+ *
+ * The compact tool always finishes on a `toolUse` turn first. The model then
+ * gets one more assistant turn to finish its response after seeing the tool
+ * result. Consuming the request on `agent_end` is too late: `session.prompt()`
+ * returns before prior `agent_end` extension work fully drains, so a stale
+ * `agent_end` from the previous run can steal a newer compact request. The
+ * first assistant `turn_end` whose stop reason is not `toolUse` is the proven
+ * boundary for starting deferred compaction exactly once.
+ *
+ * @param event - Turn lifecycle event
+ * @returns True when deferred compaction should start now
+ */
+function shouldStartDeferredCompactOnTurnEnd(event: TurnEndEvent): boolean {
+	return event.message.role === "assistant" && event.message.stopReason !== "toolUse";
+}
+
+/**
+ * Starts the deferred compact flow and wires continuation/error cleanup.
+ *
+ * @param pi - Extension API used to enqueue the hidden continuation message
+ * @param ctx - Extension context with compact/UI capabilities
+ * @param options - Deferred compact request options
+ * @returns Nothing
+ */
+function startDeferredCompact(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	options: { customInstructions?: string }
+): void {
+	// Show explicit UI feedback while compaction runs. Without this,
+	// users only see the deferred tool message and no live progress signal.
+	ctx.ui?.setWorkingMessage?.("Compacting session…");
+	startCompactProgress(ctx);
+
+	ctx.compact({
+		customInstructions: options.customInstructions,
+		onComplete: () => {
+			stopCompactProgress();
+
+			// Transition from compaction indicators to resuming indicators.
+			// setWorkingMessage queues as pendingWorkingMessage (no loader
+			// exists after executeCompaction stops it). Applied automatically
+			// when agent_start creates the loader. Footer status is visible
+			// immediately — covers the brief gap before the loader appears.
+			resumingAfterCompact = true;
+			ctx.ui?.setWorkingMessage?.("Resuming task…");
+			ctx.ui?.setStatus?.("compact", "⏳ resuming");
+
+			// Always schedule continuation. Safety nets prevent duplicate prompts:
+			// 1. turn_start listener cancels if flushCompactionQueue already started a turn
+			// 2. isIdle() check at timer expiry skips if agent is streaming
+			// 3. sendCustomMessage queues as steering if agent started mid-delay
+			//
+			// Previously gated on hasCompactionQueuedMessages(), but that method
+			// checked both the compaction queue AND session steering — causing a
+			// false positive when steering messages were queued before compact.
+			// flushCompactionQueue only processes compactionQueuedMessages, so
+			// session steering messages were orphaned. See plan 160.
+			//
+			// 200ms gives session.prompt()'s async setup (API key resolution,
+			// compaction check) time to settle. The turn_start listener cancels
+			// this timer if a turn starts before it fires (defense-in-depth).
+			continuationTimer = timerScheduler.setTimeout(() => {
+				continuationTimer = null;
+				if (ctx.isIdle()) {
+					pi.sendMessage(
+						{
+							customType: "compact-continue",
+							content:
+								"Session compaction is complete. Continue with the task " +
+								"you were working on before compaction was triggered.",
+							display: false,
+						},
+						{ triggerTurn: true }
+					);
+				} else {
+					// User sent a message during compaction — their turn is
+					// handling things, clean up our indicators.
+					resumingAfterCompact = false;
+					ctx.ui?.setStatus?.("compact", undefined);
+					ctx.ui?.setWorkingMessage?.();
+				}
+			}, 200);
+		},
+		onError: () => {
+			stopCompactProgress();
+			ctx.ui?.setWorkingMessage?.();
+			ctx.ui?.setStatus?.("compact", undefined);
+			// Framework's executeCompaction handles error/cancel
+			// display. No continuation on failure — user decides.
+		},
+	});
 }
 
 /**
@@ -299,8 +484,8 @@ WHEN NOT TO USE:
 
 				case "compact": {
 					// Don't call ctx.compact() here — it aborts the agent mid-tool-call,
-					// orphaning the tool execution spinner (plan 95/98). Defer to the
-					// agent_end hook so the tool completes normally first.
+					// orphaning the tool execution spinner (plan 95/98). Defer to a
+					// proven turn_end boundary so the tool completes normally first.
 					pendingCompact = { customInstructions: undefined };
 
 					return {
@@ -350,93 +535,23 @@ WHEN NOT TO USE:
 	// ── Deferred compact ─────────────────────────────────────────
 
 	/**
-	 * Fires compact after the agent finishes its turn. This avoids the
-	 * spinner-hang caused by aborting the agent mid-tool-execution.
-	 * The tool sets `pendingCompact`, then agent_end picks it up.
+	 * Fires compact on the first safe assistant `turn_end` after the compact tool
+	 * returns. The immediate `toolUse` turn is too early because the model has not
+	 * finished its post-tool response yet, while `agent_end` is too late because a
+	 * stale `agent_end` from the previous run can steal a newer pending request.
 	 *
-	 * After compaction completes, checks whether the agent is idle. When the
-	 * model triggered compaction (vs. the user typing during it), the
-	 * framework's `flushCompactionQueue` finds no queued messages and the
-	 * agent sits at the input prompt — even though the model promised to
-	 * continue. We fix this by sending a hidden continuation message via
-	 * `pi.sendMessage()` with `triggerTurn: true` to re-prompt the agent.
-	 *
-	 * A short `setTimeout` allows `flushCompactionQueue`'s fire-and-forget
-	 * async path to settle first, so we don't conflict with user-queued
-	 * messages that already restarted the agent.
-	 *
-	 * @see Plan 98 — deferred compact to agent_end (introduced idle-after-compact)
+	 * @see Plan 98 — deferred compact moved out of the tool handler
 	 * @see Plan 157 — auto-continue after model-triggered compaction
+	 * @see Plan 191 — stale prior agent_end could consume a later compact request
 	 */
-	pi.on("agent_end", (_event, ctx) => {
-		if (!pendingCompact) return;
+	pi.on("turn_end", (event, ctx) => {
+		if (!pendingCompact || !shouldStartDeferredCompactOnTurnEnd(event)) {
+			return;
+		}
 
 		const options = pendingCompact;
 		pendingCompact = null;
-
-		// Show explicit UI feedback while compaction runs. Without this,
-		// users only see the deferred tool message and no live progress signal.
-		ctx.ui?.setWorkingMessage?.("Compacting session…");
-		startCompactProgress(ctx);
-
-		ctx.compact({
-			customInstructions: options.customInstructions,
-			onComplete: () => {
-				stopCompactProgress();
-
-				// Transition from compaction indicators to resuming indicators.
-				// setWorkingMessage queues as pendingWorkingMessage (no loader
-				// exists after executeCompaction stops it). Applied automatically
-				// when agent_start creates the loader. Footer status is visible
-				// immediately — covers the brief gap before the loader appears.
-				resumingAfterCompact = true;
-				ctx.ui?.setWorkingMessage?.("Resuming task…");
-				ctx.ui?.setStatus?.("compact", "⏳ resuming");
-
-				// Always schedule continuation. Safety nets prevent duplicate prompts:
-				// 1. turn_start listener cancels if flushCompactionQueue already started a turn
-				// 2. isIdle() check at timer expiry skips if agent is streaming
-				// 3. sendCustomMessage queues as steering if agent started mid-delay
-				//
-				// Previously gated on hasCompactionQueuedMessages(), but that method
-				// checked both the compaction queue AND session steering — causing a
-				// false positive when steering messages were queued before compact.
-				// flushCompactionQueue only processes compactionQueuedMessages, so
-				// session steering messages were orphaned. See plan 160.
-				//
-				// 200ms gives session.prompt()'s async setup (API key resolution,
-				// compaction check) time to settle. The turn_start listener cancels
-				// this timer if a turn starts before it fires (defense-in-depth).
-				continuationTimer = setTimeout(() => {
-					continuationTimer = null;
-					if (ctx.isIdle()) {
-						pi.sendMessage(
-							{
-								customType: "compact-continue",
-								content:
-									"Session compaction is complete. Continue with the task " +
-									"you were working on before compaction was triggered.",
-								display: false,
-							},
-							{ triggerTurn: true }
-						);
-					} else {
-						// User sent a message during compaction — their turn is
-						// handling things, clean up our indicators.
-						resumingAfterCompact = false;
-						ctx.ui?.setStatus?.("compact", undefined);
-						ctx.ui?.setWorkingMessage?.();
-					}
-				}, 200);
-			},
-			onError: () => {
-				stopCompactProgress();
-				ctx.ui?.setWorkingMessage?.();
-				ctx.ui?.setStatus?.("compact", undefined);
-				// Framework's executeCompaction handles error/cancel
-				// display. No continuation on failure — user decides.
-			},
-		});
+		startDeferredCompact(pi, ctx, options);
 	});
 
 	/**
@@ -450,10 +565,7 @@ WHEN NOT TO USE:
 	 * now active and showing the pending working message ("Resuming task…").
 	 */
 	pi.on("turn_start", (_event, ctx) => {
-		if (continuationTimer) {
-			clearTimeout(continuationTimer);
-			continuationTimer = null;
-		}
+		clearContinuationTimer();
 		if (!resumingAfterCompact) return;
 		resumingAfterCompact = false;
 		ctx.ui?.setStatus?.("compact", undefined);
@@ -464,13 +576,8 @@ WHEN NOT TO USE:
 	 * session switches before the turn ends.
 	 */
 	pi.on("session_before_switch", (_event, ctx) => {
-		pendingCompact = null;
-		resumingAfterCompact = false;
-		stopCompactProgress();
-		if (continuationTimer) {
-			clearTimeout(continuationTimer);
-			continuationTimer = null;
-		}
+		clearCompactRuntimeState();
 		ctx.ui?.setStatus?.("compact", undefined);
+		ctx.ui?.setWorkingMessage?.();
 	});
 }

--- a/src/__tests__/interactive-compact-path.test.ts
+++ b/src/__tests__/interactive-compact-path.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Interactive-path regression for model-invoked `/compact`.
+ *
+ * Runs the real InteractiveMode in a child process under a pseudo-TTY so the
+ * test exercises the same compaction path as the TUI instead of the headless
+ * SessionRunner path.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const PYTHON_BIN = "python3";
+const tempDirs: string[] = [];
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const slashCommandBridgePath = join(repoRoot, "extensions/slash-command-bridge/index.js");
+const sdkPath = join(repoRoot, "src/sdk.js");
+const mockModelPath = join(repoRoot, "test-utils/mock-model.js");
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		rmSync(dir, { force: true, recursive: true });
+	}
+	tempDirs.length = 0;
+});
+
+interface InteractiveScenarioResult {
+	readonly code: number | null;
+	readonly stderr: string;
+	readonly stdout: string;
+}
+
+/**
+ * Allocates an isolated temp directory tracked for cleanup.
+ *
+ * @param prefix - Temp directory prefix
+ * @returns Absolute temp directory path
+ */
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/**
+ * Runs the real interactive compact scenario in a pseudo-terminal child process.
+ *
+ * @returns Exit code with captured stdout/stderr
+ */
+function runInteractiveCompactScenario(): Promise<InteractiveScenarioResult> {
+	const tallowHome = makeTempDir("tallow-plan191-home-");
+	const scriptDir = join(
+		repoRoot,
+		".tmp-tests",
+		`interactive-compact-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	tempDirs.push(scriptDir);
+	const scenarioPath = join(scriptDir, "interactive-compact-check.ts");
+	const scenarioSource = `
+		import { mkdtempSync, rmSync } from "node:fs";
+		import { tmpdir } from "node:os";
+		import { join } from "node:path";
+		import { InteractiveMode } from "@mariozechner/pi-coding-agent";
+		import slashCommandBridge from ${JSON.stringify(slashCommandBridgePath)};
+		import { createTallowSession } from ${JSON.stringify(sdkPath)};
+		import { createMockModel, createScriptedStreamFn } from ${JSON.stringify(mockModelPath)};
+
+		const cwd = mkdtempSync(join(tmpdir(), "tallow-plan191-ui-"));
+		let sawResumed = false;
+		let sawCompact = false;
+
+		const cleanup = () => {
+			rmSync(cwd, { recursive: true, force: true });
+		};
+
+		const log = (message) => {
+			process.stdout.write(message + "\\n");
+		};
+
+		const tracker = (pi) => {
+			pi.on("tool_result", async (event) => {
+				if (event.toolName !== "run_slash_command") return;
+				if (event.details?.command !== "compact") return;
+				log("MARKER: tool_result");
+			});
+
+			pi.on("agent_start", async () => {
+				if (sawCompact) {
+					log("MARKER: agent_start_after_compact");
+				}
+			});
+
+			pi.on("turn_start", async () => {
+				if (sawCompact) {
+					log("MARKER: turn_start_after_compact");
+				}
+			});
+
+			pi.on("session_before_compact", async () => {
+				log("MARKER: session_before_compact");
+				return {
+					compaction: {
+						summary: "MARKER_SUMMARY",
+						firstKeptEntryId: undefined,
+						tokensBefore: 123,
+						details: { modifiedFiles: [], readFiles: [] },
+					},
+				};
+			});
+
+			pi.on("session_compact", async () => {
+				sawCompact = true;
+				log("MARKER: session_compact");
+			});
+		};
+
+		const { session } = await createTallowSession({
+			cwd,
+			model: createMockModel(),
+			provider: "mock",
+			apiKey: "mock-api-key",
+			session: { type: "memory" },
+			noBundledExtensions: true,
+			noBundledSkills: true,
+			extensionFactories: [slashCommandBridge, tracker],
+			settings: {
+				compaction: {
+					enabled: true,
+					keepRecentTokens: 1,
+					reserveTokens: 10,
+				},
+			},
+		});
+
+		session.agent.streamFn = createScriptedStreamFn([
+			{ text: "warmup complete" },
+			{ toolCalls: [{ name: "run_slash_command", arguments: { command: "compact" } }] },
+			{ text: "finishing response before compaction" },
+			{ text: "resumed after compact" },
+		]);
+
+		const mode = new InteractiveMode(session, {
+			initialMessages: ["warm up the session", "compact the session"],
+			verbose: false,
+		});
+
+		const timeout = setTimeout(() => {
+			log("MARKER: timeout");
+			cleanup();
+			mode.stop();
+			process.exit(2);
+		}, 10000);
+
+		const unsubscribe = session.subscribe((event) => {
+			if (event.type === "message_end") {
+				const text =
+					typeof event.message.content === "string"
+						? event.message.content
+						: event.message.content
+								.filter((part) => part.type === "text")
+								.map((part) => part.text)
+								.join("\\n");
+
+				if (event.message.role === "custom" && text.includes("Session compaction is complete")) {
+					log("MARKER: continuation_message");
+				}
+
+				if (
+					event.message.role === "assistant" &&
+					text.includes("finishing response before compaction")
+				) {
+					log("MARKER: post_tool_response");
+				}
+
+				if (event.message.role === "assistant" && text.includes("resumed after compact")) {
+					sawResumed = true;
+					log("MARKER: resumed_once");
+					clearTimeout(timeout);
+					unsubscribe();
+					setTimeout(() => {
+						cleanup();
+						mode.stop();
+						process.exit(0);
+					}, 300);
+				}
+			}
+		});
+
+		await mode.run();
+		clearTimeout(timeout);
+		unsubscribe();
+		cleanup();
+		if (!sawResumed) {
+			log("MARKER: mode_run_returned");
+			process.exit(3);
+		}
+	`;
+
+	const runnerPath = join(scriptDir, "pty-runner.py");
+	const runnerSource = `
+import os
+import pty
+import select
+import shutil
+import subprocess
+import sys
+import time
+
+repo_root = ${JSON.stringify(repoRoot)}
+scenario_path = ${JSON.stringify(scenarioPath)}
+tallow_home = ${JSON.stringify(tallowHome)}
+master, slave = pty.openpty()
+env = os.environ.copy()
+env["TALLOW_HOME"] = tallow_home
+proc = subprocess.Popen(
+    ["bun", scenario_path],
+    cwd=repo_root,
+    stdin=slave,
+    stdout=slave,
+    stderr=slave,
+    env=env,
+    close_fds=True,
+)
+os.close(slave)
+out = bytearray()
+deadline = time.time() + 15
+while True:
+    if time.time() > deadline:
+        proc.kill()
+        break
+    ready, _, _ = select.select([master], [], [], 0.2)
+    if master in ready:
+        try:
+            chunk = os.read(master, 65536)
+            if chunk:
+                out.extend(chunk)
+        except OSError:
+            pass
+    if proc.poll() is not None:
+        while True:
+            try:
+                chunk = os.read(master, 65536)
+                if not chunk:
+                    break
+                out.extend(chunk)
+            except OSError:
+                break
+        break
+os.close(master)
+sys.stdout.write(out.decode(errors="ignore"))
+sys.exit(0 if proc.returncode is None else proc.returncode)
+`;
+
+	mkdirSync(scriptDir, { recursive: true });
+	writeFileSync(scenarioPath, scenarioSource, "utf-8");
+	writeFileSync(runnerPath, runnerSource, "utf-8");
+
+	return new Promise((resolveResult) => {
+		const child = spawn(PYTHON_BIN, [runnerPath], {
+			cwd: repoRoot,
+			env: process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		const killTimer = setTimeout(() => {
+			child.kill("SIGKILL");
+		}, 20000);
+
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		child.on("close", (code) => {
+			clearTimeout(killTimer);
+			resolveResult({ code, stderr, stdout });
+		});
+	});
+}
+
+/**
+ * Returns the index of a marker inside captured child output.
+ *
+ * @param output - Captured stdout from the interactive child process
+ * @param marker - Marker text to locate
+ * @returns First marker position in the output string
+ */
+function markerIndex(output: string, marker: string): number {
+	return output.indexOf(marker);
+}
+
+describe("interactive compact path", () => {
+	it("shows the real TUI compaction summary and resumes exactly once", async () => {
+		const result = await runInteractiveCompactScenario();
+		const output = `${result.stdout}\n${result.stderr}`;
+
+		expect(result.code).toBe(0);
+		expect(output).not.toContain("MARKER: timeout");
+		expect(output).not.toContain("MARKER: mode_run_returned");
+		expect(output).toContain("MARKER: tool_result");
+		expect(output).toContain("MARKER: post_tool_response");
+		expect(output).toContain("MARKER: session_before_compact");
+		expect(output).toContain("MARKER: session_compact");
+		expect(output).toContain("[compaction]");
+		expect(output).toContain("Compacted from 123 tokens");
+		expect(output).toContain("MARKER: continuation_message");
+		expect(output).toContain("MARKER: agent_start_after_compact");
+		expect(output).toContain("MARKER: turn_start_after_compact");
+		expect(output).toContain("MARKER: resumed_once");
+
+		const toolResultIndex = markerIndex(output, "MARKER: tool_result");
+		const postToolIndex = markerIndex(output, "MARKER: post_tool_response");
+		const beforeCompactIndex = markerIndex(output, "MARKER: session_before_compact");
+		const compactIndex = markerIndex(output, "MARKER: session_compact");
+		const summaryLabelIndex = markerIndex(output, "[compaction]");
+		const summaryBodyIndex = markerIndex(output, "Compacted from 123 tokens");
+		const continuationIndex = markerIndex(output, "MARKER: continuation_message");
+		const agentStartIndex = markerIndex(output, "MARKER: agent_start_after_compact");
+		const turnStartIndex = markerIndex(output, "MARKER: turn_start_after_compact");
+		const resumedIndex = markerIndex(output, "MARKER: resumed_once");
+
+		expect(toolResultIndex).toBeGreaterThanOrEqual(0);
+		expect(postToolIndex).toBeGreaterThan(toolResultIndex);
+		expect(beforeCompactIndex).toBeGreaterThan(postToolIndex);
+		expect(compactIndex).toBeGreaterThan(beforeCompactIndex);
+		expect(summaryLabelIndex).toBeGreaterThan(compactIndex);
+		expect(summaryBodyIndex).toBeGreaterThan(summaryLabelIndex);
+		expect(agentStartIndex).toBeGreaterThan(summaryBodyIndex);
+		expect(turnStartIndex).toBeGreaterThan(agentStartIndex);
+		expect(continuationIndex).toBeGreaterThan(turnStartIndex);
+		expect(resumedIndex).toBeGreaterThan(continuationIndex);
+	});
+}, 20000);

--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -26,6 +26,8 @@ interface FakeEvent {
 class FakeInteractiveMode {
 	defaultEditor: { onEscape?: () => void } = {};
 	escapeCalls = 0;
+	executeCompactionCalls = 0;
+	executeCompactionResult: unknown = { summary: "ok" };
 	flushCalls = 0;
 	handleBashCommandCalls = 0;
 	handleEventCalls = 0;
@@ -37,7 +39,10 @@ class FakeInteractiveMode {
 	pendingBashComponents: unknown[] = [];
 	pendingWorkingMessage: unknown = "stale";
 	renderRequests = 0;
-	session = { isStreaming: false };
+	session = {
+		extensionRunner: { compactFn: undefined as ((options?: unknown) => void) | undefined },
+		isStreaming: false,
+	};
 	statusClears = 0;
 	updateCalls = 0;
 	ui = {
@@ -86,6 +91,37 @@ class FakeInteractiveMode {
 		this.defaultEditor.onEscape = () => {
 			this.escapeCalls++;
 		};
+	}
+
+	/**
+	 * Base initExtensions implementation used by the patch wrapper.
+	 *
+	 * @returns Promise resolved after recording the lifecycle step
+	 */
+	async initExtensions(): Promise<void> {
+		this.lifecycleCalls.push("initExtensions");
+	}
+
+	/**
+	 * Base reload implementation used by the patch wrapper.
+	 *
+	 * @returns Promise resolved after recording the lifecycle step
+	 */
+	async handleReloadCommand(): Promise<void> {
+		this.lifecycleCalls.push("handleReloadCommand");
+	}
+
+	/**
+	 * Base executeCompaction implementation used by the patch wrapper.
+	 *
+	 * @param _customInstructions - Optional compaction instructions
+	 * @param _isAuto - Whether the compaction is automatic
+	 * @returns Configured mock compaction result
+	 */
+	async executeCompaction(_customInstructions?: string, _isAuto = false): Promise<unknown> {
+		this.executeCompactionCalls++;
+		this.lifecycleCalls.push("executeCompaction");
+		return this.executeCompactionResult;
 	}
 
 	/**
@@ -501,6 +537,76 @@ describe("patchInteractiveModePrototype", () => {
 			| (() => boolean)
 			| undefined;
 		expect(hasQueued?.()).toBe(false);
+	});
+
+	it("rebinds extension compact to InteractiveMode compaction on init and reload", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+		let completed = 0;
+
+		await mode.initExtensions();
+		expect(typeof mode.session.extensionRunner.compactFn).toBe("function");
+
+		mode.session.extensionRunner.compactFn?.({
+			onComplete: () => {
+				completed++;
+			},
+		});
+		await Promise.resolve();
+
+		expect(mode.executeCompactionCalls).toBe(1);
+		expect(completed).toBe(1);
+
+		await mode.handleReloadCommand();
+		mode.session.extensionRunner.compactFn?.({
+			onComplete: () => {
+				completed++;
+			},
+		});
+		await Promise.resolve();
+
+		expect(mode.executeCompactionCalls).toBe(2);
+		expect(completed).toBe(2);
+	});
+
+	it("defers extension compact until agent_end when the session is still streaming", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+		let completed = 0;
+
+		await mode.initExtensions();
+		mode.session.isStreaming = true;
+		mode.session.extensionRunner.compactFn?.({
+			onComplete: () => {
+				completed++;
+			},
+		});
+
+		expect(mode.executeCompactionCalls).toBe(0);
+
+		mode.session.isStreaming = false;
+		await mode.handleEvent({ type: "agent_end" });
+
+		expect(mode.executeCompactionCalls).toBe(1);
+		expect(completed).toBe(1);
+	});
+
+	it("treats undefined InteractiveMode compaction results as cleanup-worthy errors", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+		mode.executeCompactionResult = undefined;
+		let errorMessage: string | undefined;
+
+		await mode.initExtensions();
+		mode.session.extensionRunner.compactFn?.({
+			onError: (error: Error) => {
+				errorMessage = error.message;
+			},
+		});
+		await Promise.resolve();
+
+		expect(mode.executeCompactionCalls).toBe(1);
+		expect(errorMessage).toBe("Compaction did not complete");
 	});
 
 	// ── message_update coalescing (plan 176) ──────────────────────────────

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -8,8 +8,19 @@ interface QueuedMessagesLike {
 	steering?: unknown[];
 }
 
+interface CompactOptionsLike {
+	customInstructions?: string;
+	onComplete?: ((result: unknown) => void) | undefined;
+	onError?: ((error: Error) => void) | undefined;
+}
+
+interface ExtensionRunnerLike {
+	compactFn?: ((options?: CompactOptionsLike) => void) | undefined;
+}
+
 interface SessionLike {
 	autoCompactionEnabled?: boolean;
+	extensionRunner?: ExtensionRunnerLike;
 	isStreaming?: boolean;
 }
 
@@ -19,8 +30,13 @@ interface InteractiveModeInstanceLike {
 		| ((...args: unknown[]) => { notify?: ((...args: unknown[]) => unknown) | undefined })
 		| undefined;
 	defaultEditor?: { onEscape?: (() => void) | undefined };
+	executeCompaction?:
+		| ((customInstructions?: string, isAuto?: boolean) => Promise<unknown>)
+		| undefined;
 	flushPendingBashComponents?: (() => void) | undefined;
 	getAllQueuedMessages?: (() => QueuedMessagesLike) | undefined;
+	handleReloadCommand?: (() => Promise<unknown>) | undefined;
+	initExtensions?: (() => Promise<unknown>) | undefined;
 	loadingAnimation?: unknown;
 	pendingWorkingMessage?: unknown;
 	restoreQueuedMessagesToEditor?: ((options?: { abort?: boolean }) => unknown) | undefined;
@@ -53,6 +69,8 @@ interface InteractiveModePrototypeLike {
 		| ((command: string, excludeFromContext?: boolean) => Promise<unknown>)
 		| undefined;
 	handleEvent?: ((event: InteractiveModeEventLike) => Promise<unknown>) | undefined;
+	handleReloadCommand?: ((...args: unknown[]) => Promise<unknown>) | undefined;
+	initExtensions?: ((...args: unknown[]) => Promise<unknown>) | undefined;
 	setupKeyHandlers?: ((...args: unknown[]) => unknown) | undefined;
 }
 
@@ -137,6 +155,11 @@ const CONTINUATION_SIGNAL_EVENT_TYPES = new Set([
 const compactionRetryWatchdogTimers = new WeakMap<
 	InteractiveModeInstanceLike,
 	ReturnType<typeof setTimeout>
+>();
+
+const pendingInteractiveExtensionCompact = new WeakMap<
+	InteractiveModeInstanceLike,
+	CompactOptionsLike
 >();
 
 /**
@@ -278,6 +301,74 @@ function notifyFromInteractiveMode(
 }
 
 /**
+ * Runs InteractiveMode compaction and forwards completion/cleanup callbacks.
+ *
+ * @param mode - Interactive mode instance
+ * @param options - Extension compact options
+ * @returns Nothing
+ */
+function runInteractiveExtensionCompact(
+	mode: InteractiveModeInstanceLike,
+	options?: CompactOptionsLike
+): void {
+	const executeCompaction = mode.executeCompaction;
+	if (typeof executeCompaction !== "function") {
+		return;
+	}
+
+	void (async () => {
+		try {
+			const result = await executeCompaction.call(mode, options?.customInstructions, false);
+			if (result !== undefined) {
+				options?.onComplete?.(result);
+				return;
+			}
+
+			options?.onError?.(new Error("Compaction did not complete"));
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			options?.onError?.(err);
+		}
+	})();
+}
+
+/**
+ * Rebinds extension `ctx.compact()` to InteractiveMode's compaction path.
+ *
+ * AgentSession binds extension contexts to raw `session.compact()`, which skips
+ * InteractiveMode's UI rebuild, compaction summary rendering, and queued-input
+ * flush. In the TUI that leaves model-invoked compact stuck on extension-owned
+ * status text instead of running the same path as `/compact` or extension
+ * shortcuts. Rebinding here makes extension-driven compaction use
+ * `executeCompaction()` while preserving extension callbacks for completion and
+ * cleanup.
+ *
+ * When compaction is requested while the current agent run is still streaming,
+ * the actual `executeCompaction()` call must wait until the following
+ * `agent_end`. Triggering it earlier recreates the original abort/disconnect
+ * race, because `executeCompaction()` aborts the session before InteractiveMode
+ * has finished its own `agent_end` cleanup.
+ *
+ * @param mode - Interactive mode instance whose extension runner should be rebound
+ * @returns Nothing
+ */
+function bindInteractiveExtensionCompact(mode: InteractiveModeInstanceLike): void {
+	const extensionRunner = mode.session?.extensionRunner;
+	if (!extensionRunner) {
+		return;
+	}
+
+	extensionRunner.compactFn = (options?: CompactOptionsLike) => {
+		if (mode.session?.isStreaming) {
+			pendingInteractiveExtensionCompact.set(mode, options ?? {});
+			return;
+		}
+
+		runInteractiveExtensionCompact(mode, options);
+	};
+}
+
+/**
  * Clears the liveness watchdog timer for an interactive mode instance.
  *
  * @param mode - Interactive mode instance
@@ -398,6 +489,30 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 	if (prototype.__tallow_stale_ui_patch_applied__) return;
 	prototype.__tallow_stale_ui_patch_applied__ = true;
 
+	const originalInitExtensions = prototype.initExtensions;
+	if (typeof originalInitExtensions === "function") {
+		prototype.initExtensions = async function (
+			this: InteractiveModeInstanceLike,
+			...args: unknown[]
+		) {
+			const result = await originalInitExtensions.call(this, ...args);
+			bindInteractiveExtensionCompact(this);
+			return result;
+		};
+	}
+
+	const originalHandleReloadCommand = prototype.handleReloadCommand;
+	if (typeof originalHandleReloadCommand === "function") {
+		prototype.handleReloadCommand = async function (
+			this: InteractiveModeInstanceLike,
+			...args: unknown[]
+		) {
+			const result = await originalHandleReloadCommand.call(this, ...args);
+			bindInteractiveExtensionCompact(this);
+			return result;
+		};
+	}
+
 	const originalHandleEvent = prototype.handleEvent;
 	if (typeof originalHandleEvent === "function") {
 		prototype.handleEvent = async function (
@@ -472,6 +587,12 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 				this.flushPendingBashComponents?.();
 				this.updatePendingMessagesDisplay?.();
 				this.ui?.requestRender?.();
+
+				const deferredCompact = pendingInteractiveExtensionCompact.get(this);
+				if (deferredCompact) {
+					pendingInteractiveExtensionCompact.delete(this);
+					runInteractiveExtensionCompact(this, deferredCompact);
+				}
 			}
 			return result;
 		};

--- a/test-utils/manual-timer-scheduler.ts
+++ b/test-utils/manual-timer-scheduler.ts
@@ -1,0 +1,131 @@
+/** Runtime timer interface used by deterministic test schedulers. */
+export interface RuntimeTimerScheduler {
+	readonly now: () => number;
+	readonly setInterval: (callback: () => void, intervalMs: number) => unknown;
+	readonly clearInterval: (handle: unknown) => void;
+	readonly setTimeout: (callback: () => void, delayMs: number) => unknown;
+	readonly clearTimeout: (handle: unknown) => void;
+}
+
+interface ScheduledTask {
+	readonly callback: () => void;
+	readonly delayMs: number;
+	readonly id: number;
+	readonly type: "interval" | "timeout";
+	runAt: number;
+}
+
+/**
+ * Deterministic in-memory timer scheduler for tests.
+ *
+ * Timers only run when the test advances time explicitly via {@link advanceBy}.
+ */
+export class ManualTimerScheduler {
+	readonly runtime: RuntimeTimerScheduler;
+
+	private nowMs = 0;
+	private nextId = 1;
+	private readonly tasks = new Map<number, ScheduledTask>();
+
+	constructor() {
+		this.runtime = {
+			now: () => this.nowMs,
+			setInterval: (callback, intervalMs) => this.schedule("interval", callback, intervalMs),
+			clearInterval: (handle) => this.clear(handle),
+			setTimeout: (callback, delayMs) => this.schedule("timeout", callback, delayMs),
+			clearTimeout: (handle) => this.clear(handle),
+		};
+	}
+
+	/**
+	 * Advances the scheduler clock and runs any timers due within the interval.
+	 *
+	 * @param milliseconds - Virtual time to advance
+	 * @returns Nothing
+	 */
+	advanceBy(milliseconds: number): void {
+		const targetTime = this.nowMs + Math.max(0, milliseconds);
+
+		while (true) {
+			const nextTask = this.findNextDueTask(targetTime);
+			if (!nextTask) {
+				break;
+			}
+
+			this.nowMs = nextTask.runAt;
+
+			if (nextTask.type === "timeout") {
+				this.tasks.delete(nextTask.id);
+				nextTask.callback();
+				continue;
+			}
+
+			nextTask.runAt += nextTask.delayMs;
+			nextTask.callback();
+		}
+
+		this.nowMs = targetTime;
+	}
+
+	/**
+	 * Returns the number of currently scheduled timers.
+	 *
+	 * @returns Count of pending timers
+	 */
+	getPendingTaskCount(): number {
+		return this.tasks.size;
+	}
+
+	/**
+	 * Removes a scheduled timer by handle.
+	 *
+	 * @param handle - Timer handle returned by the runtime scheduler
+	 * @returns Nothing
+	 */
+	private clear(handle: unknown): void {
+		if (typeof handle !== "number") {
+			return;
+		}
+
+		this.tasks.delete(handle);
+	}
+
+	/**
+	 * Returns the next task due on or before the target time.
+	 *
+	 * @param targetTime - Upper bound for eligible tasks
+	 * @returns Earliest due task, if any
+	 */
+	private findNextDueTask(targetTime: number): ScheduledTask | undefined {
+		let nextTask: ScheduledTask | undefined;
+		for (const task of this.tasks.values()) {
+			if (task.runAt > targetTime) {
+				continue;
+			}
+			if (!nextTask || task.runAt < nextTask.runAt || task.id < nextTask.id) {
+				nextTask = task;
+			}
+		}
+		return nextTask;
+	}
+
+	/**
+	 * Registers a timeout or interval task.
+	 *
+	 * @param type - Timer kind
+	 * @param callback - Callback to run when due
+	 * @param delayMs - Delay before the timer becomes due
+	 * @returns Numeric timer handle
+	 */
+	private schedule(type: "interval" | "timeout", callback: () => void, delayMs: number): number {
+		const id = this.nextId++;
+		this.tasks.set(id, {
+			callback,
+			delayMs: Math.max(0, delayMs),
+			id,
+			type,
+			runAt: this.nowMs + Math.max(0, delayMs),
+		});
+		return id;
+	}
+}

--- a/test-utils/session-runner.ts
+++ b/test-utils/session-runner.ts
@@ -26,6 +26,8 @@ export interface SessionRunnerOptions {
 	extensionFactories?: ExtensionFactory[];
 	/** Working directory (default: temp dir). */
 	cwd?: string;
+	/** Session settings overrides applied during creation. */
+	settings?: Record<string, unknown>;
 }
 
 /** Result from running a prompt through the session. */
@@ -77,6 +79,7 @@ export class SessionRunner {
 				noBundledExtensions: true,
 				noBundledSkills: true,
 				extensionFactories: options.extensionFactories,
+				settings: options.settings,
 			});
 		});
 


### PR DESCRIPTION
## What

Repair model-invoked `/compact` so it reliably compacts and resumes in both the headless and interactive TUI paths.

## Why

The previous design kept getting the lifecycle wrong:
- headless runs could lose the deferred compact/resume handoff
- interactive TUI runs could show compacting UI without reaching the real compaction summary path
- continuation after compaction was still unreliable in the live TUI flow

## How

- move slash-command-bridge deferred compact consumption to the proven assistant `turn_end` boundary
- add a deterministic timer scheduler seam and replace wall-clock sleeps in compact tests
- add an ordered headless regression that proves tool result → compaction → exactly one resumed turn
- rebind extension-driven `ctx.compact()` in interactive mode to `InteractiveMode.executeCompaction()`
- defer that interactive compaction call until `agent_end` when requested during streaming
- add an interactive pseudo-TTY regression that proves the real TUI compaction summary and resumed turn

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` passes
- [x] `bun run build` succeeds
- [x] `bun run test:docs` passes
- [ ] All required GitHub checks are green (verify with `gh pr checks <pr-number>`)

### Docs impact

- [x] Existing slash-command-bridge docs updated
- [x] `bun run test:docs` passes
