### PR TITLE
fix(plan-mode): show action menu when execution ends with incomplete steps

### DIFF
--- a/extensions/plan-mode-tool/__tests__/agent-end-execution.test.ts
+++ b/extensions/plan-mode-tool/__tests__/agent-end-execution.test.ts
@@ -92,6 +92,7 @@ function createUIContext(
 			setStatus() {},
 			setEditorComponent() {},
 			setWidget() {},
+			setWorkingMessage() {},
 			async select(title: string, options: string[]) {
 				selectCalls.push({ title, options });
 				return selectReturn;
@@ -135,6 +136,7 @@ function createHeadlessContext(entries: unknown[] = []): ExtensionContext {
 			setStatus() {},
 			setEditorComponent() {},
 			setWidget() {},
+			setWorkingMessage() {},
 			theme: {
 				fg(_token: string, value: string) {
 					return value;

--- a/extensions/plan-mode-tool/index.ts
+++ b/extensions/plan-mode-tool/index.ts
@@ -31,6 +31,7 @@ import {
 } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { getIcon } from "../_icons/index.js";
+import { renderBorderedBox } from "../_shared/bordered-box.js";
 import {
 	detectPlanIntent,
 	extractTodoItems,
@@ -705,19 +706,22 @@ If you receive [PLAN GUIDANCE — Step n: ...], treat it as user steering for th
 			}
 		}
 
-		// Show plan steps and prompt for next action
+		// Show plan steps in a bordered widget above the editor
 		if (todoItems.length > 0) {
-			const todoListText = todoItems
-				.map((t, i) => `${i + 1}. ${getIcon("pending")} ${t.text}`)
-				.join("\n");
-			pi.sendMessage(
-				{
-					customType: "plan-todo-list",
-					content: `**Plan Steps (${todoItems.length}):**\n\n${todoListText}`,
-					display: true,
+			ctx.ui.setWidget("plan-steps", (_tui, theme) => ({
+				render(width: number): string[] {
+					const stepLines = todoItems.map(
+						(t) => `${theme.fg("muted", `${getIcon("pending")} `)}${t.text}`
+					);
+					return renderBorderedBox(stepLines, width, {
+						title: `PLAN (${todoItems.length} steps)`,
+						style: "rounded",
+						borderColorFn: (s: string) => theme.fg("warning", s),
+						titleColorFn: (s: string) => theme.fg("warning", s),
+					});
 				},
-				{ triggerTurn: false }
-			);
+				invalidate() {},
+			}));
 		}
 
 		ctx.ui.setWorkingMessage(Loader.HIDE);
@@ -727,6 +731,9 @@ If you receive [PLAN GUIDANCE — Step n: ...], treat it as user steering for th
 			"Stay in plan mode",
 			"Refine the plan",
 		]);
+
+		// Clear the plan steps widget after user makes a choice
+		ctx.ui.setWidget("plan-steps", undefined);
 
 		if (choice?.startsWith("Execute")) {
 			planModeEnabled = false;


### PR DESCRIPTION
## Summary

The plan-mode agent_end handler silently returned when execution finished without all steps marked complete via `[DONE:n]` markers. This left the UI stuck showing "EXECUTING PLAN" with unchecked boxes and no input prompt — the user had no signal the agent had stopped.

## Changes

### fix(plan-mode): show action menu when execution ends with incomplete steps
- Add else branch in `agent_end` with a select menu (continue, provide guidance, mark done, abort) when steps remain incomplete
- Remove execution-mode banner, todo widget, and footer counter — these duplicated the tasks extension's progress tracking
- Keep plan-mode-only visuals (banner, status, editor border) intact
- Hide loader spinner before showing select menus to prevent stale "thinking" UI
- 8 new tests covering all select menu paths, headless fallback, widget removal, and the `[DONE:n]` happy path

### feat(plan-mode): render plan steps in bordered widget
- Replace the inline sendMessage plan-todo-list with a bordered box widget above the editor
- Uses rounded borders in warning color with a titled header showing step count
- Widget is visible while the user considers the select menu, then cleared after selection

## Test plan
```bash
bun test extensions/plan-mode-tool
```