### PR TITLE
fix(plan-mode): avoid headless auto-enable

### DIFF
--- a/extensions/plan-mode-tool/__tests__/index.test.ts
+++ b/extensions/plan-mode-tool/__tests__/index.test.ts
@@ -63,10 +63,10 @@ function registerMockTools(pi: ExtensionAPI): void {
  * @param entries - Session entries returned by sessionManager.getEntries
  * @returns Context object compatible with extension handlers
  */
-function createContext(entries: unknown[] = []): ExtensionContext {
+function createContext(entries: unknown[] = [], hasUI = true): ExtensionContext {
 	return {
 		cwd: process.cwd(),
-		hasUI: true,
+		hasUI,
 		ui: {
 			notify() {},
 			setStatus() {},
@@ -179,5 +179,35 @@ describe("plan-mode strict readonly enforcement", () => {
 			ctx
 		);
 		expect(blockedResult).toMatchObject({ block: true });
+	});
+
+	test("auto-enable only triggers for interactive UI input", async () => {
+		const [result] = await harness.fireEvent(
+			"input",
+			{ source: "interactive", text: "plan only fix auth" },
+			createContext([], true)
+		);
+
+		expect(result).toEqual({ action: "transform", text: "fix auth" });
+		expect(harness.api.getActiveTools()).toEqual(
+			PLAN_MODE_ALLOWED_TOOLS.filter((name) => BASELINE_TOOLS.includes(name))
+		);
+	});
+
+	test("auto-enable ignores headless or non-interactive input", async () => {
+		const [headlessResult] = await harness.fireEvent(
+			"input",
+			{ source: "interactive", text: "plan only fix auth" },
+			createContext([], false)
+		);
+		const [rpcResult] = await harness.fireEvent(
+			"input",
+			{ source: "rpc", text: "plan only fix auth" },
+			createContext([], true)
+		);
+
+		expect(headlessResult).toEqual({ action: "continue" });
+		expect(rpcResult).toEqual({ action: "continue" });
+		expect(harness.api.getActiveTools()).toEqual([...BASELINE_TOOLS]);
 	});
 });

--- a/extensions/plan-mode-tool/index.ts
+++ b/extensions/plan-mode-tool/index.ts
@@ -378,10 +378,15 @@ Use action "enable" to enter plan mode, "disable" to exit, or "status" to check 
 		}
 	});
 
-	// Auto-enable plan mode when user expresses planning intent in natural language
+	// Auto-enable plan mode when a human interactive session explicitly signals planning intent.
 	pi.on("input", async (event, ctx) => {
 		// No-op if already in plan mode
 		if (planModeEnabled) {
+			return { action: "continue" as const };
+		}
+
+		// Headless/orchestrated prompts should never toggle workflow modes via string matching.
+		if (!ctx.hasUI || event.source !== "interactive") {
 			return { action: "continue" as const };
 		}
 

--- a/src/__tests__/startup-profiles.test.ts
+++ b/src/__tests__/startup-profiles.test.ts
@@ -40,12 +40,14 @@ function makeTempDir(prefix: string): string {
  */
 async function createProfileSession(options: {
 	readonly additionalExtensions: readonly string[];
+	readonly disabledExtensions?: readonly string[];
 	readonly startupProfile: "interactive" | "headless";
 	readonly tools?: ReturnType<typeof parseToolFlag>;
 }): Promise<TallowSession> {
 	const tallow = await createTallowSession({
 		additionalExtensions: [...options.additionalExtensions],
 		cwd: makeTempDir("tallow-startup-profile-cwd-"),
+		disabledExtensions: options.disabledExtensions ? [...options.disabledExtensions] : undefined,
 		extensionsOnly: true,
 		model: createMockModel(),
 		provider: "mock",
@@ -154,6 +156,18 @@ describe("startup profile extension loading", () => {
 
 		expect(tallow.extensions.errors).toEqual([]);
 		expect(loaded).toContain(basename(uiToolExtension));
+	});
+
+	test("disabledExtensions skips selected extensions for one session", async () => {
+		const tallow = await createProfileSession({
+			additionalExtensions: ["clear", "plan-mode-tool"],
+			disabledExtensions: ["plan-mode-tool"],
+			startupProfile: "interactive",
+		});
+
+		const loaded = getLoadedExtensionIds(tallow);
+		expect(loaded).toContain("clear");
+		expect(loaded).not.toContain("plan-mode-tool");
 	});
 });
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -118,6 +118,9 @@ export interface TallowSessionOptions {
 	/** Additional extension selectors (bundled IDs or filesystem paths). */
 	additionalExtensions?: string[];
 
+	/** Extension IDs to skip for this session after resource discovery. */
+	disabledExtensions?: string[];
+
 	/** Load only explicitly selected extension selectors (IDs/paths). */
 	extensionsOnly?: boolean;
 
@@ -1074,6 +1077,7 @@ interface StartupTimingLogger {
 /** Options for startup-time extension filtering policies. */
 interface ExtensionStartupPolicyOptions {
 	readonly blockProjectExtensions: boolean;
+	readonly disabledExtensionNames: ReadonlySet<string>;
 	readonly projectExtensionsDir: string;
 	readonly startupProfile: TallowStartupProfile;
 }
@@ -1380,6 +1384,21 @@ function isProjectExtensionPath(extensionPath: string, projectExtensionsDir: str
 }
 
 /**
+ * Derives a stable extension runtime ID from a discovered extension path.
+ *
+ * Directory-based extensions use the directory basename. File-based extensions
+ * drop the final extension suffix so option matching stays ergonomic.
+ *
+ * @param extensionPath - Absolute extension file or directory path
+ * @returns Stable extension identifier used by startup filters
+ */
+function getExtensionRuntimeId(extensionPath: string): string {
+	const name = basename(extensionPath);
+	const suffixIndex = name.lastIndexOf(".");
+	return suffixIndex > 0 ? name.slice(0, suffixIndex) : name;
+}
+
+/**
  * Determine whether an extension is a purely interactive UI extension in headless mode.
  *
  * Tool availability is always preserved: extensions that register tools at runtime,
@@ -1426,6 +1445,16 @@ function applyExtensionStartupPolicies(
 ): LoadExtensionsResult {
 	let filteredExtensions = base.extensions;
 	let changed = false;
+
+	if (options.disabledExtensionNames.size > 0) {
+		const allowed = filteredExtensions.filter(
+			(ext) => !options.disabledExtensionNames.has(getExtensionRuntimeId(ext.path))
+		);
+		if (allowed.length !== filteredExtensions.length) {
+			filteredExtensions = allowed;
+			changed = true;
+		}
+	}
 
 	if (options.blockProjectExtensions) {
 		const blocked = filteredExtensions.filter(
@@ -1703,8 +1732,11 @@ export async function createTallowSession(
 	}
 
 	const dedupedExtensionPaths = [...new Set(additionalExtensionPaths)];
+	const disabledExtensionNames = new Set(options.disabledExtensions ?? []);
 	const shouldApplyExtensionStartupPolicies =
-		shouldBlockProjectExtensions || startupProfile === "headless";
+		shouldBlockProjectExtensions ||
+		startupProfile === "headless" ||
+		disabledExtensionNames.size > 0;
 	const explicitToolRestrictionNames = resolveExplicitToolRestrictionNames(options);
 
 	const loader = new DefaultResourceLoader({
@@ -1734,6 +1766,7 @@ export async function createTallowSession(
 			? (base) =>
 					applyExtensionStartupPolicies(base, {
 						blockProjectExtensions: shouldBlockProjectExtensions,
+						disabledExtensionNames,
 						projectExtensionsDir,
 						startupProfile,
 					})


### PR DESCRIPTION
## Summary
- stop plan-mode auto-enable from triggering in headless/orchestrated sessions
- add a per-session `disabledExtensions` SDK option for deterministic extension filtering
- cover both behaviors with regression tests

## Changes Made
- require `ctx.hasUI && event.source === "interactive"` before plan-mode auto-enable can trigger
- add `disabledExtensions` to `createTallowSession()` and apply it during startup extension filtering
- add tests for plan-mode input gating and disabled extension loading

## Testing
- `bun test extensions/plan-mode-tool/__tests__/index.test.ts src/__tests__/startup-profiles.test.ts`
- `bun x tsc --noEmit`