### PR TITLE
fix(custom-footer): respect unknown post-compaction usage

### DIFF
--- a/extensions/custom-footer/__tests__/index.test.ts
+++ b/extensions/custom-footer/__tests__/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import type { ContextUsage } from "@mariozechner/pi-coding-agent";
+import { formatContextUsageDisplay } from "../context-display.js";
+
+describe("formatContextUsageDisplay", () => {
+	it("formats known context usage as a percentage", () => {
+		const usage: ContextUsage = { contextWindow: 272_000, percent: 27.5625, tokens: 74_967 };
+		const result = formatContextUsageDisplay(usage, 0, true);
+
+		expect(result.percent).toBeCloseTo(27.56139705882353);
+		expect(result.text).toBe("27.6%/272k (auto)");
+	});
+
+	it("preserves unknown usage after compaction", () => {
+		const usage: ContextUsage = { contextWindow: 272_000, percent: null, tokens: null };
+
+		expect(formatContextUsageDisplay(usage, 0, true)).toEqual({
+			percent: null,
+			text: "?/272k (auto)",
+		});
+	});
+
+	it("falls back to the model context window when usage is unavailable", () => {
+		expect(formatContextUsageDisplay(undefined, 1_000_000, true)).toEqual({
+			percent: 0,
+			text: "0.0%/1.0M (auto)",
+		});
+	});
+});

--- a/extensions/custom-footer/context-display.ts
+++ b/extensions/custom-footer/context-display.ts
@@ -1,0 +1,49 @@
+import type { ContextUsage } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Formats token counts with k/M suffixes for readability.
+ *
+ * @param count - Token count to format
+ * @returns Formatted string (e.g., "1.2k", "5M")
+ */
+function formatTokens(count: number): string {
+	if (count < 1000) return count.toString();
+	if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
+	if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
+	if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+	return `${Math.round(count / 1_000_000)}M`;
+}
+
+/**
+ * Formats footer context usage without reusing stale pre-compaction token counts.
+ *
+ * `ctx.getContextUsage()` intentionally returns `tokens: null` after compaction
+ * until a fresh assistant response arrives. The footer must preserve that
+ * unknown state instead of showing a bogus percentage from stale usage data.
+ *
+ * @param usage - Current context usage snapshot, if available
+ * @param fallbackContextWindow - Active model context window when usage is unavailable
+ * @param autoCompactEnabled - Whether to append the auto-compaction indicator
+ * @returns Display text plus raw percentage for severity coloring
+ */
+export function formatContextUsageDisplay(
+	usage: ContextUsage | undefined,
+	fallbackContextWindow: number,
+	autoCompactEnabled: boolean
+): { readonly percent: number | null; readonly text: string } {
+	const autoIndicator = autoCompactEnabled ? " (auto)" : "";
+	const contextWindow = usage?.contextWindow ?? fallbackContextWindow;
+	const tokens = usage ? usage.tokens : 0;
+
+	if (contextWindow <= 0) {
+		return { percent: null, text: `?/?${autoIndicator}` };
+	}
+
+	const windowText = formatTokens(contextWindow);
+	if (tokens === null) {
+		return { percent: null, text: `?/${windowText}${autoIndicator}` };
+	}
+
+	const percent = (tokens / contextWindow) * 100;
+	return { percent, text: `${percent.toFixed(1)}%/${windowText}${autoIndicator}` };
+}

--- a/extensions/custom-footer/index.ts
+++ b/extensions/custom-footer/index.ts
@@ -19,6 +19,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { runGitCommandSync } from "../_shared/shell-policy.js";
+import { formatContextUsageDisplay } from "./context-display.js";
 
 /** Cached git repository state for the footer display. */
 interface GitState {
@@ -204,26 +205,12 @@ export default function customFooterExtension(pi: ExtensionAPI): void {
 						}
 					}
 
-					// Get context percentage from last assistant message
-					const branch = sessionManager.getBranch();
-					const lastAssistant = branch
-						.slice()
-						.reverse()
-						.find(
-							(e) =>
-								e.type === "message" &&
-								e.message.role === "assistant" &&
-								(e.message as unknown as Record<string, string>).stopReason !== "aborted"
-						);
-
-					let contextTokens = 0;
-					if (lastAssistant?.type === "message" && lastAssistant.message.role === "assistant") {
-						const u = lastAssistant.message.usage;
-						contextTokens = u.input + u.output + u.cacheRead + u.cacheWrite;
-					}
-
-					const contextWindow = model?.contextWindow || 0;
-					const contextPercentValue = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
+					const contextUsage = extensionCtx.getContextUsage();
+					const { percent: contextPercentValue, text: contextDisplay } = formatContextUsageDisplay(
+						contextUsage,
+						model?.contextWindow ?? 0,
+						autoCompactEnabled
+					);
 
 					// Build path (replace home with ~)
 					let pwd = process.cwd();
@@ -270,10 +257,10 @@ export default function customFooterExtension(pi: ExtensionAPI): void {
 					if (totalCost) statsParts.push(`$${totalCost.toFixed(3)}`);
 
 					// Context percentage with color
-					const autoIndicator = autoCompactEnabled ? " (auto)" : "";
-					const contextDisplay = `${contextPercentValue.toFixed(1)}%/${formatTokens(contextWindow)}${autoIndicator}`;
 					let contextStr: string;
-					if (contextPercentValue > 90) {
+					if (contextPercentValue === null) {
+						contextStr = theme.fg("dim", contextDisplay);
+					} else if (contextPercentValue > 90) {
 						contextStr = theme.fg("error", contextDisplay);
 					} else if (contextPercentValue > 70) {
 						contextStr = theme.fg("warning", contextDisplay);


### PR DESCRIPTION
## Summary
- stop the custom footer from deriving context usage from the last assistant message
- use the session context usage snapshot so post-compaction `tokens: null` stays unknown instead of rendering stale percentages
- add focused tests for known, unknown, and fallback context display states

## Testing
- `bun test extensions/custom-footer/__tests__/index.test.ts`
- `bun x tsc -p tsconfig.json --noEmit`

## Notes
This fixes the misleading footer state where auto-compaction could still show values like `105.9%/272k` because the footer was reusing stale pre-compaction usage.