### PR TITLE
fix(models): patch stale gpt-5.4 context metadata

### DIFF
--- a/extensions/teams-tool/sessions/spawn.ts
+++ b/extensions/teams-tool/sessions/spawn.ts
@@ -15,6 +15,7 @@ import {
 	SessionManager,
 	SettingsManager,
 } from "@mariozechner/pi-coding-agent";
+import { applyKnownModelMetadataOverrides } from "../../../src/model-metadata-overrides.js";
 import { getTallowPath } from "../../_shared/tallow-paths.js";
 import { type RoutingHints, routeModel } from "../../subagent-tool/model-router.js";
 import { resolveStandardTools } from "../state/team-view.js";
@@ -64,6 +65,7 @@ export async function spawnTeammateSession(
 	// API keys and custom model definitions from the main session.
 	const authStorage = AuthStorage.create(getTallowPath("auth.json"));
 	const modelRegistry = new ModelRegistry(authStorage, getTallowPath("models.json"));
+	applyKnownModelMetadataOverrides(modelRegistry);
 
 	const model = modelRegistry.find(resolved.provider, resolved.id);
 	if (!model) {

--- a/src/__tests__/model-metadata-overrides.test.ts
+++ b/src/__tests__/model-metadata-overrides.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { type Api, getModels, type Model } from "@mariozechner/pi-ai";
+import { applyKnownModelMetadataOverrides } from "../model-metadata-overrides.js";
+
+/**
+ * Builds a mutable model registry stub for override testing.
+ *
+ * @param models - Models to expose through `getAll()`
+ * @returns Registry-like object backed by the provided array
+ */
+function createRegistry(models: Model<Api>[]): { getAll(): Model<Api>[] } {
+	return { getAll: () => models };
+}
+
+/**
+ * Clones a built-in model so tests can mutate it without affecting shared fixtures.
+ *
+ * @param provider - Provider name containing the built-in model
+ * @param id - Model identifier to clone
+ * @returns Mutable clone of the requested model
+ * @throws {Error} When the built-in model does not exist
+ */
+function cloneBuiltInModel(provider: string, id: string): Model<Api> {
+	const model = getModels(provider).find((entry) => entry.id === id);
+	if (!model) {
+		throw new Error(`Missing built-in model ${provider}/${id}`);
+	}
+	return structuredClone(model);
+}
+
+describe("applyKnownModelMetadataOverrides", () => {
+	it("patches stale OpenAI GPT-5.4 context metadata", () => {
+		const openai = cloneBuiltInModel("openai", "gpt-5.4");
+		const codex = cloneBuiltInModel("openai-codex", "gpt-5.4");
+		const copilot = cloneBuiltInModel("github-copilot", "gpt-5.4");
+		const registry = createRegistry([openai, codex, copilot]);
+
+		const applied = applyKnownModelMetadataOverrides(registry);
+
+		expect(applied).toBe(2);
+		expect(openai.contextWindow).toBe(1_000_000);
+		expect(codex.contextWindow).toBe(1_000_000);
+		expect(copilot.contextWindow).toBe(400_000);
+	});
+
+	it("does not clobber explicit user overrides", () => {
+		const codex = cloneBuiltInModel("openai-codex", "gpt-5.4");
+		codex.contextWindow = 1_000_000;
+		const registry = createRegistry([codex]);
+
+		const applied = applyKnownModelMetadataOverrides(registry);
+
+		expect(applied).toBe(0);
+		expect(codex.contextWindow).toBe(1_000_000);
+	});
+});

--- a/src/model-metadata-overrides.ts
+++ b/src/model-metadata-overrides.ts
@@ -1,0 +1,47 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
+const KNOWN_CONTEXT_WINDOW_OVERRIDES = {
+	openai: {
+		"gpt-5.4": 1_000_000,
+	},
+	"openai-codex": {
+		"gpt-5.4": 1_000_000,
+	},
+} as const;
+
+const STALE_CONTEXT_WINDOW = 272_000;
+
+interface ModelRegistryLike {
+	getAll(): Model<Api>[];
+}
+
+/**
+ * Correct known stale upstream model metadata without clobbering explicit user overrides.
+ *
+ * The upstream pi-ai registry currently ships `gpt-5.4` with a 272k context
+ * window for the OpenAI and OpenAI Codex providers, while current OpenAI docs
+ * advertise a 1M context window. User `models.json` overrides should continue
+ * to win, so this patch only rewrites entries that still carry the known stale
+ * 272k value.
+ *
+ * @param modelRegistry - Registry containing built-in and user-overridden models
+ * @returns Number of models patched in place
+ */
+export function applyKnownModelMetadataOverrides(modelRegistry: ModelRegistryLike): number {
+	let applied = 0;
+
+	for (const model of modelRegistry.getAll()) {
+		const providerOverrides =
+			KNOWN_CONTEXT_WINDOW_OVERRIDES[model.provider as keyof typeof KNOWN_CONTEXT_WINDOW_OVERRIDES];
+		if (!providerOverrides) continue;
+
+		const contextWindow = providerOverrides[model.id as keyof typeof providerOverrides];
+		if (!contextWindow) continue;
+		if (model.contextWindow !== STALE_CONTEXT_WINDOW) continue;
+
+		model.contextWindow = contextWindow;
+		applied += 1;
+	}
+
+	return applied;
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -38,6 +38,7 @@ import {
 	TALLOW_VERSION,
 } from "./config.js";
 import { applyInteractiveModeStaleUiPatch } from "./interactive-mode-patch.js";
+import { applyKnownModelMetadataOverrides } from "./model-metadata-overrides.js";
 import {
 	createTelemetryHandle,
 	extractTraceContextFromEnv,
@@ -1553,6 +1554,7 @@ export async function createTallowSession(
 		);
 	}
 	const modelRegistry = new ModelRegistry(authStorage, join(tallowHome, "models.json"));
+	applyKnownModelMetadataOverrides(modelRegistry);
 
 	// ── Runtime API key (not persisted) ──────────────────────────────────────
 	// Accepts programmatic SDK `apiKey` option or env overrides:


### PR DESCRIPTION
## Summary
- patch known stale upstream metadata for `openai/gpt-5.4` and `openai-codex/gpt-5.4` from 272k to 1M at runtime
- only rewrite entries that still have the known stale 272k value so explicit user `models.json` overrides continue to win
- apply the same correction to teammate sessions, which create their own model registry

## Why
The bundled upstream registry currently reports 272k for these models even though current OpenAI docs advertise a 1M context window. This causes misleading context accounting and premature compaction behavior unless users manually override `~/.tallow/models.json`.

## Testing
- `bun test src/__tests__/model-metadata-overrides.test.ts`
- `bun test extensions/teams-tool/__tests__/spawn-auth.test.ts`
- `bun run --cwd packages/tallow-tui build`
- `bun x tsc -p tsconfig.json --noEmit`

## Notes
This is a narrow runtime patch, not a blanket provider rewrite. It deliberately avoids touching other providers like GitHub Copilot or any user-configured overrides.
