### PR TITLE
fix(slash-command-bridge): guard against model-initiated compaction at low usage

### DIFF
--- a/extensions/slash-command-bridge/index.ts
+++ b/extensions/slash-command-bridge/index.ts
@@ -395,7 +395,8 @@ WHEN TO USE:
 
 WHEN NOT TO USE:
 - The user already ran the command themselves
-- You want to start a new session (suggest the user run /clear instead)`,
+- You want to start a new session (suggest the user run /clear instead)
+- Context usage is below 80% — there is no need to compact proactively. Do NOT compact between tasks "just in case". Compaction destroys conversation history and should only happen when the context window is nearly full.`,
 		parameters: Type.Object({
 			command: Type.String({
 				description:
@@ -490,6 +491,34 @@ WHEN NOT TO USE:
 				}
 
 				case "compact": {
+					// Guard: reject model-initiated compact when context usage is low.
+					// The model frequently compacts proactively at 15-30% usage, wasting
+					// context and losing valuable conversation history. Only allow
+					// programmatic compact when usage exceeds 80% of the context window.
+					const compactUsage = ctx.getContextUsage?.();
+					if (
+						compactUsage &&
+						compactUsage.tokens !== null &&
+						compactUsage.tokens > 0 &&
+						compactUsage.contextWindow > 0
+					) {
+						const usagePercent = (compactUsage.tokens / compactUsage.contextWindow) * 100;
+						if (usagePercent < 80) {
+							return {
+								content: [
+									{
+										type: "text",
+										text:
+											`Context usage is only ${Math.round(usagePercent)}% — compaction is not needed yet. ` +
+											"The session has plenty of context space remaining. " +
+											"Continue working normally; compaction will happen automatically when needed.",
+									},
+								],
+								details: { command, rejected: true, usagePercent },
+							};
+						}
+					}
+
 					// Don't call ctx.compact() here — it aborts the agent mid-tool-call,
 					// orphaning the tool execution spinner (plan 95/98). Defer to a
 					// proven turn_end boundary so the tool completes normally first.


### PR DESCRIPTION
## Summary

- **Root cause**: Opus 4.6 was compacting at 10-31% context usage because the **model itself** was calling `run_slash_command({command: "compact"})` proactively — 76% of observed compactions were model-initiated
- **Why**: Every turn injects "/compact" as an available tool, the description encourages its use, and `ctx.compact()` has no usage threshold — it compacts unconditionally
- **Fix**: Add an 80% usage threshold guard + explicit tool description guidance against proactive compaction

## Analysis

| Stat | Value |
|------|-------|
| Compaction events analyzed | 21 |
| Model-initiated (`run_slash_command`) | 16 (76%) |
| Other (user `/compact` or unknown) | 5 (24%) |
| Token range at compaction | 102K – 314K (10-31% of 1M) |
| Framework auto-compact threshold | 984K (98.4% of 1M) |

The framework's `shouldCompact()` is working correctly — it triggers at ~98% usage. The model was bypassing it entirely via the tool path.

## Changes Made

- **Usage guard**: When the model calls compact via `run_slash_command`, check context usage first. If below 80%, reject with a clear message explaining context is fine
- **Tool description**: Added explicit `WHEN NOT TO USE` guidance that compact should not be used proactively when usage is below 80%

## Testing

- Existing slash-command-bridge tests pass (14/14)
- Typecheck clean (core + extensions)
- Build clean