### PR TITLE
fix(interactive): stop latching compaction status

### DIFF
--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -269,11 +269,10 @@ describe("patchInteractiveModePrototype", () => {
 		expect(mode.flushCalls).toBe(1);
 		expect(mode.pendingBashComponents).toEqual([]);
 		expect(mode.pendingWorkingMessage).toBeUndefined();
-		// statusContainer is NOT cleared here — the original framework guards
-		// this behind `if (this.loadingAnimation)`. Unconditionally clearing
-		// strips the compacting loader during model-triggered compaction
-		// (plan 159, bug 2).
-		expect(mode.statusClears).toBe(0);
+		// statusContainer IS cleared on a normal agent_end (no active compaction).
+		// During compaction, the flag prevents clearing the compacting loader
+		// (plan 159, bug 2). For normal turns we must clear to avoid a stale spinner.
+		expect(mode.statusClears).toBe(1);
 		expect(mode.updateCalls).toBe(1);
 		expect(mode.renderRequests).toBe(1);
 
@@ -802,5 +801,71 @@ describe("patchInteractiveModePrototype", () => {
 		expect(mode.steeringQueue).toEqual([]);
 		expect(mode.followUpQueue).toEqual([]);
 		expect(mode.editorText).toBe("steer1\n\nsteer2\n\nfollow1");
+	});
+
+	// ── spinner clearing on agent_end ─────────────────────────────────────
+
+	it("does NOT clear statusContainer on agent_end when auto-compaction is active", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		// Start auto-compaction flow
+		await mode.handleEvent({ type: "auto_compaction_start" });
+		// agent_end arrives while compaction is still running
+		await mode.handleEvent({ type: "agent_end" });
+
+		// Compaction loader must not be stripped
+		expect(mode.statusClears).toBe(0);
+	});
+
+	it("clears statusContainer on agent_end after auto-compaction fully completes", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		// Full compaction cycle completes (willRetry=false)
+		await mode.handleEvent({ type: "auto_compaction_start" });
+		await mode.handleEvent({
+			type: "auto_compaction_end",
+			willRetry: false,
+			result: { summary: "ok" },
+		});
+		// Next agent_end is a normal turn — spinner should clear
+		await mode.handleEvent({ type: "agent_end" });
+
+		expect(mode.statusClears).toBe(1);
+	});
+
+	it("does NOT clear statusContainer on agent_end when compaction retry is still in flight", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		await mode.handleEvent({ type: "auto_compaction_start" });
+		// willRetry=true means the loader must survive until continuation actually starts
+		await mode.handleEvent({ type: "auto_compaction_end", willRetry: true });
+		await mode.handleEvent({ type: "agent_end" });
+
+		expect(mode.statusClears).toBe(0);
+	});
+
+	it("clears statusContainer on agent_end after retry continuation starts", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		await mode.handleEvent({ type: "auto_compaction_start" });
+		await mode.handleEvent({ type: "auto_compaction_end", willRetry: true });
+		await mode.handleEvent({ type: "message_start" });
+		await mode.handleEvent({ type: "agent_end" });
+
+		expect(mode.statusClears).toBe(1);
+	});
+
+	it("does not latch compaction status from ordinary continuation signals", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		await mode.handleEvent({ type: "agent_start" });
+		await mode.handleEvent({ type: "agent_end" });
+
+		expect(mode.statusClears).toBe(1);
 	});
 });

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -164,6 +164,10 @@ const compactionRetryWatchdogTimers = new WeakMap<
 	ReturnType<typeof setTimeout>
 >();
 
+type AutoCompactionStatus = "running" | "waiting_for_retry";
+
+const autoCompactionStatus = new WeakMap<InteractiveModeInstanceLike, AutoCompactionStatus>();
+
 const pendingInteractiveExtensionCompact = new WeakMap<
 	InteractiveModeInstanceLike,
 	CompactOptionsLike
@@ -415,6 +419,58 @@ function isCompactionContinuationSignal(event: InteractiveModeEventLike): boolea
 }
 
 /**
+ * Marks one interactive mode instance as actively auto-compacting.
+ *
+ * @param mode - Interactive mode instance
+ * @returns Nothing
+ */
+function markAutoCompactionRunning(mode: InteractiveModeInstanceLike): void {
+	autoCompactionStatus.set(mode, "running");
+}
+
+/**
+ * Marks one interactive mode instance as waiting for retry continuation.
+ *
+ * @param mode - Interactive mode instance
+ * @returns Nothing
+ */
+function markAutoCompactionWaitingForRetry(mode: InteractiveModeInstanceLike): void {
+	autoCompactionStatus.set(mode, "waiting_for_retry");
+}
+
+/**
+ * Clears any tracked auto-compaction status for one interactive mode instance.
+ *
+ * @param mode - Interactive mode instance
+ * @returns Nothing
+ */
+function clearAutoCompactionStatus(mode: InteractiveModeInstanceLike): void {
+	autoCompactionStatus.delete(mode);
+}
+
+/**
+ * Returns whether status clearing should stay suppressed for auto-compaction.
+ *
+ * @param mode - Interactive mode instance
+ * @returns True when a compaction loader should still be preserved
+ */
+function shouldPreserveCompactionStatus(mode: InteractiveModeInstanceLike): boolean {
+	return autoCompactionStatus.has(mode);
+}
+
+/**
+ * Transitions retry-waiting compaction state back to normal once continuation starts.
+ *
+ * @param mode - Interactive mode instance
+ * @returns Nothing
+ */
+function markCompactionContinuationStarted(mode: InteractiveModeInstanceLike): void {
+	if (autoCompactionStatus.get(mode) === "waiting_for_retry") {
+		clearAutoCompactionStatus(mode);
+	}
+}
+
+/**
  * Drains orphaned session steering/follow-up messages to the editor.
  *
  * Called at agent_end to clear zombie "Steering: ..." / "Follow-up: ..." lines
@@ -560,8 +616,14 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 			this: InteractiveModeInstanceLike,
 			event: InteractiveModeEventLike
 		) {
-			if (event?.type === "auto_compaction_start" || isCompactionContinuationSignal(event)) {
+			if (event?.type === "auto_compaction_start") {
 				clearCompactionRetryWatchdog(this);
+				markAutoCompactionRunning(this);
+			}
+
+			if (isCompactionContinuationSignal(event)) {
+				clearCompactionRetryWatchdog(this);
+				markCompactionContinuationStarted(this);
 			}
 
 			// ── message_update coalescing (plan 176) ─────────────────────────
@@ -609,9 +671,11 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 
 			if (event?.type === "auto_compaction_end") {
 				if (event.willRetry === true) {
+					markAutoCompactionWaitingForRetry(this);
 					armCompactionRetryWatchdog(this);
 				} else {
 					clearCompactionRetryWatchdog(this);
+					clearAutoCompactionStatus(this);
 				}
 				if (isAmbiguousCompactionEndState(event)) {
 					notifyFromInteractiveMode(this, AMBIGUOUS_COMPACTION_END_WARNING_TEXT, "warning");
@@ -621,10 +685,13 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 			if (event?.type === "agent_end") {
 				clearCompactionRetryWatchdog(this);
 				this.pendingWorkingMessage = undefined;
-				// NOTE: Do NOT clear statusContainer here — the original framework
-				// guards this behind `if (this.loadingAnimation)`. Unconditionally
-				// clearing it strips the compacting loader that extensions add during
-				// model-triggered compaction (plan 159, bug 2).
+				// Preserve the compaction loader only while compaction is still
+				// running or while a promised retry has not actually started yet.
+				// Once continuation begins, later agent_end events must clear the
+				// spinner like any normal turn.
+				if (!shouldPreserveCompactionStatus(this)) {
+					this.statusContainer?.clear?.();
+				}
 				this.flushPendingBashComponents?.();
 
 				// Drain orphaned session steering/follow-up messages to the editor.


### PR DESCRIPTION
## Summary
- stop treating ordinary continuation events as active auto-compaction state
- only preserve the status line while compaction is actually running or while waiting for a promised retry to start
- add regressions for retry continuation and ordinary agent start/end cleanup

## Testing
- `bun test src/__tests__/interactive-mode-patch.test.ts src/__tests__/interactive-compact-path.test.ts`
- `bun x tsc --noEmit`