### PR TITLE
fix(interactive): clear stale loader in getUserInput as last-resort safety net

### DIFF
--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -114,6 +114,19 @@ class FakeInteractiveMode {
 		return "bash-ok";
 	}
 
+	/** Tracks getUserInput calls. */
+	getUserInputCalls = 0;
+
+	/**
+	 * Base getUserInput implementation used by the patch wrapper.
+	 *
+	 * @returns Promise resolved with marker text
+	 */
+	async getUserInput(): Promise<string> {
+		this.getUserInputCalls++;
+		return "user-input";
+	}
+
 	/**
 	 * Base setupKeyHandlers implementation that installs the default escape handler.
 	 *
@@ -303,6 +316,31 @@ describe("patchInteractiveModePrototype", () => {
 
 		expect(stopCalled).toBe(true);
 		expect(mode.loadingAnimation).toBeNull();
+	});
+
+	it("clears stale loader in getUserInput as last-resort safety net", async () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+
+		const mode = new FakeInteractiveMode();
+		let stopCalled = false;
+		mode.loadingAnimation = {
+			stop: () => {
+				stopCalled = true;
+			},
+		};
+		mode.pendingWorkingMessage = "stale";
+
+		// getUserInput is called by the main loop when the agent is idle.
+		// It should clear any lingering loader regardless of whether
+		// _emit(agent_end) has fired yet.
+		const result = await mode.getUserInput();
+
+		expect(result).toBe("user-input");
+		expect(stopCalled).toBe(true);
+		expect(mode.loadingAnimation).toBeNull();
+		expect(mode.pendingWorkingMessage).toBeUndefined();
+		expect(mode.statusClears).toBe(1);
+		expect(mode.forceRenderRequests).toBe(1);
 	});
 
 	it("suppresses overflow payloads while keeping a visible overflow indicator", async () => {

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -72,6 +72,7 @@ interface InteractiveModeEventLike {
 interface InteractiveModePrototypeLike {
 	__tallow_stale_ui_patch_applied__?: boolean;
 	createExtensionUIContext?: ((...args: unknown[]) => Record<string, unknown>) | undefined;
+	getUserInput?: (() => Promise<unknown>) | undefined;
 	handleBashCommand?:
 		| ((command: string, excludeFromContext?: boolean) => Promise<unknown>)
 		| undefined;
@@ -755,6 +756,35 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 			this.updatePendingMessagesDisplay?.();
 			this.ui?.requestRender?.();
 			return result;
+		};
+	}
+
+	// ── getUserInput: last-resort loader cleanup ─────────────────────────
+	//
+	// The main loop calls getUserInput() right after session.prompt() returns.
+	// At this point the agent is done, but _emit(agent_end) may not have fired
+	// yet — it runs through _agentEventQueue which is a separate microtask
+	// chain that _emitExtensionEvent must complete first. If any extension
+	// handler is slow, the loader persists because neither the upstream
+	// agent_end handler nor the tallow post-handler has run.
+	//
+	// Clearing the loader here is unconditionally safe: getUserInput means the
+	// agent is idle — there is never a legitimate "Working..." at this point.
+	const originalGetUserInput = prototype.getUserInput;
+	if (typeof originalGetUserInput === "function") {
+		prototype.getUserInput = async function (this: InteractiveModeInstanceLike) {
+			// Stop the loader interval and remove it from the container.
+			if (this.loadingAnimation) {
+				this.loadingAnimation.stop?.();
+				this.loadingAnimation = null;
+			}
+			this.pendingWorkingMessage = undefined;
+			if (!shouldPreserveCompactionStatus(this)) {
+				this.statusContainer?.clear?.();
+			}
+			this.ui?.requestRender?.(true);
+
+			return originalGetUserInput.call(this);
 		};
 	}
 


### PR DESCRIPTION
## Problem

"Working..." spinner persists permanently after the agent finishes — every single time. The previous fixes (`4c20b8c`, `0514dda`) both run inside the `handleEvent(agent_end)` path, which depends on `_emit(agent_end)` firing. But `_emit` only fires after `_emitExtensionEvent(agent_end)` completes, and `session.prompt()` resolves independently — the main loop reaches `getUserInput()` before `_emit` runs.

## Fix

Patch `getUserInput()` to unconditionally clear the loader before waiting for input. This is the exact transition point from "agent working" to "idle" — there is never a legitimate `Working...` loader at this point.

Unlike the agent_end post-handler, this does NOT depend on `_emit` timing or extension handler completion.

## Testing

- 36/36 interactive-mode-patch tests pass (1 new test)
- Full suite: 2593 pass