### PR TITLE
fix(tasks): scope task groups to session context

### DIFF
--- a/extensions/__integration__/tasks-runtime.test.ts
+++ b/extensions/__integration__/tasks-runtime.test.ts
@@ -1,18 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { ExtensionHarness } from "../../test-utils/extension-harness.js";
 import { registerTasksExtension } from "../tasks/commands/register-tasks-extension.js";
-import { TaskListStore } from "../tasks/state/index.js";
+import { buildSessionTaskGroupName, TASK_GROUPS_DIR, TaskListStore } from "../tasks/state/index.js";
 
 const ORIGINAL_PI_IS_SUBAGENT = process.env.PI_IS_SUBAGENT;
 const ORIGINAL_PI_TEAM_NAME = process.env.PI_TEAM_NAME;
+const TEST_TASK_GROUPS = new Set<string>();
 
 /**
  * Build a minimal extension context for direct tool execution in tests.
  *
+ * @param options - Optional session/cwd overrides
  * @returns Stub extension context
  */
-function createContext(): ExtensionContext {
+function createContext(options?: {
+	cwd?: string;
+	entries?: Array<{ type: string; customType?: string; data?: unknown }>;
+	sessionId?: string;
+}): ExtensionContext {
 	return {
 		ui: {
 			async select() {
@@ -61,10 +69,11 @@ function createContext(): ExtensionContext {
 			setToolsExpanded() {},
 		} as ExtensionContext["ui"],
 		hasUI: false,
-		cwd: process.cwd(),
+		cwd: options?.cwd ?? process.cwd(),
 		sessionManager: {
-			getEntries: () => [],
+			getEntries: () => options?.entries ?? [],
 			appendEntry: () => {},
+			getSessionId: () => options?.sessionId ?? "test-session",
 		} as never,
 		modelRegistry: {
 			getApiKeyForProvider: async () => undefined,
@@ -110,19 +119,18 @@ function getTool(harness: ExtensionHarness, name: string): ToolDefinition {
  *
  * @param tool - Registered manage_tasks tool
  * @param params - Tool parameters
+ * @param ctx - Optional extension context override
  * @returns Tool execution result
  */
 async function execManage(
 	tool: ToolDefinition,
-	params: Record<string, unknown>
+	params: Record<string, unknown>,
+	ctx = createContext()
 ): Promise<{ content: Array<{ type: string; text?: string }>; details: unknown }> {
-	return (await tool.execute(
-		"test-tool-call",
-		params as never,
-		undefined,
-		undefined,
-		createContext()
-	)) as { content: Array<{ type: string; text?: string }>; details: unknown };
+	return (await tool.execute("test-tool-call", params as never, undefined, undefined, ctx)) as {
+		content: Array<{ type: string; text?: string }>;
+		details: unknown;
+	};
 }
 
 beforeEach(() => {
@@ -131,6 +139,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	for (const groupName of TEST_TASK_GROUPS) {
+		rmSync(join(TASK_GROUPS_DIR, groupName), { force: true, recursive: true });
+	}
+	TEST_TASK_GROUPS.clear();
 	if (ORIGINAL_PI_IS_SUBAGENT === undefined) delete process.env.PI_IS_SUBAGENT;
 	else process.env.PI_IS_SUBAGENT = ORIGINAL_PI_IS_SUBAGENT;
 	if (ORIGINAL_PI_TEAM_NAME === undefined) delete process.env.PI_TEAM_NAME;
@@ -203,6 +215,45 @@ describe("Tasks runtime wiring", () => {
 		const listText = firstText(list);
 		expect(listText).toContain("1. [completed] Analyze outage");
 		expect(listText).toContain("2. [in_progress] Deploy fix");
+	});
+
+	it("isolates file-backed task groups per session and reloads them on session_switch", async () => {
+		process.env.PI_IS_SUBAGENT = "0";
+		process.env.PI_TEAM_NAME = "foreign-shared-group";
+		const harness = ExtensionHarness.create();
+		registerTasksExtension(harness.api, new TaskListStore(null), null);
+		const manage = getTool(harness, "manage_tasks");
+		const ctxA = createContext({
+			cwd: "/tmp/workspace-a",
+			sessionId: "session-a",
+		});
+		const ctxB = createContext({
+			cwd: "/tmp/workspace-b",
+			sessionId: "session-b",
+		});
+		const groupA = buildSessionTaskGroupName("session-a", "/tmp/workspace-a");
+		const groupB = buildSessionTaskGroupName("session-b", "/tmp/workspace-b");
+		TEST_TASK_GROUPS.add(groupA);
+		TEST_TASK_GROUPS.add(groupB);
+
+		await harness.fireEvent("session_start", {}, ctxA);
+		expect(process.env.PI_TEAM_NAME).toBe(groupA);
+		await execManage(manage, { action: "add", task: "Task from session A" }, ctxA);
+		await execManage(manage, { action: "update", index: 1, status: "pending" }, ctxA);
+		expect(firstText(await execManage(manage, { action: "list" }, ctxA))).toContain(
+			"Task from session A"
+		);
+
+		await harness.fireEvent("session_switch", {}, ctxB);
+		expect(process.env.PI_TEAM_NAME).toBe(groupB);
+		expect(firstText(await execManage(manage, { action: "list" }, ctxB))).toBe("No tasks.");
+		await execManage(manage, { action: "add", task: "Task from session B" }, ctxB);
+		await execManage(manage, { action: "update", index: 1, status: "pending" }, ctxB);
+
+		await harness.fireEvent("session_switch", {}, ctxA);
+		const listA = firstText(await execManage(manage, { action: "list" }, ctxA));
+		expect(listA).toContain("Task from session A");
+		expect(listA).not.toContain("Task from session B");
 	});
 
 	it("injects active-task context before agent start and clears orphaned in-progress tasks on agent_end", async () => {

--- a/extensions/tasks/commands/register-tasks-extension.ts
+++ b/extensions/tasks/commands/register-tasks-extension.ts
@@ -32,6 +32,7 @@ import {
 import { findCompletedTasks } from "../parsing/index.js";
 import {
 	type BgTaskView,
+	buildSessionTaskGroupName,
 	cleanupStaleTeams,
 	getTextContent,
 	isAssistantMessage,
@@ -41,7 +42,7 @@ import {
 	shouldClearOnAgentEnd,
 	type Task,
 	type TaskComment,
-	type TaskListStore,
+	TaskListStore,
 	type TaskStatus,
 	type TasksState,
 	type TeamWidgetView,
@@ -75,15 +76,17 @@ const agentIdentities = new Map<string, AgentIdentity>();
  * Registers task management tools, commands, and widget.
  *
  * @param pi - Extension API for registering tools, commands, and event handlers
- * @param store - Pre-constructed {@link TaskListStore} for file persistence
- * @param teamName - Active team name (or null for session-only mode)
+ * @param initialStore - Initial {@link TaskListStore} for file persistence
+ * @param initialTeamName - Active team name (or null for session-only mode)
  */
 export function registerTasksExtension(
 	pi: ExtensionAPI,
-	store: TaskListStore,
-	teamName: string | null
+	initialStore: TaskListStore,
+	initialTeamName: string | null
 ): void {
 	const isSubagent = process.env.PI_IS_SUBAGENT === "1";
+	let store = initialStore;
+	let teamName = initialTeamName;
 	const state: TasksState = {
 		tasks: [],
 		visible: true,
@@ -1023,9 +1026,7 @@ export function registerTasksExtension(
 								return `${t.id}. ${icon} ${t.subject}${blocked}${comments}`;
 							})
 							.join("\n");
-						const mode = store.isShared
-							? ` [team: ${process.env.PI_TEAM_NAME}]`
-							: " [session-only]";
+						const mode = store.isShared ? ` [team: ${teamName}]` : " [session-only]";
 						ctx.ui.notify(`Tasks${mode}:\n${list}`, "info");
 						break;
 					}
@@ -1091,7 +1092,7 @@ export function registerTasksExtension(
 					}
 
 					case "team": {
-						const current = store.isShared ? process.env.PI_TEAM_NAME : "(none — session-only)";
+						const current = store.isShared ? teamName : "(none — session-only)";
 						const teamPath = store.path ?? "N/A";
 						ctx.ui.notify(`Shared task group: ${current}\nPath: ${teamPath}`, "info");
 						break;
@@ -1916,8 +1917,37 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 	let lastBgCount = 0;
 	let lastBgTaskCount = 0;
 
-	// Restore state on session start
-	pi.on("session_start", async (_event, ctx) => {
+	/** Resolve the shared task-group name for the current session context.
+	 * @param ctx - Active extension context
+	 * @returns Shared task-group name, or null for session-only mode
+	 */
+	function resolveTaskGroupName(ctx: ExtensionContext): string | null {
+		if (isSubagent) return process.env.PI_TEAM_NAME ?? teamName;
+		const sessionId = ctx.sessionManager.getSessionId?.();
+		if (!sessionId) return null;
+		return buildSessionTaskGroupName(sessionId, ctx.cwd);
+	}
+	/** Rebind the file-backed task store for the current session.
+	 * @param ctx - Active extension context
+	 * @returns Nothing
+	 */
+	function syncTaskGroupStore(ctx: ExtensionContext): void {
+		const nextTeamName = resolveTaskGroupName(ctx);
+		store.close();
+		if (nextTeamName !== teamName) {
+			store = new TaskListStore(nextTeamName);
+			teamName = nextTeamName;
+		}
+		if (!isSubagent) {
+			if (teamName) process.env.PI_TEAM_NAME = teamName;
+			else delete process.env.PI_TEAM_NAME;
+		}
+	}
+
+	/** Reset runtime widget/session state before loading a different session.
+	 * @returns Nothing
+	 */
+	function resetSessionState(): void {
 		foregroundSubagents = [];
 		backgroundSubagents = [];
 		backgroundTasks = [];
@@ -1926,7 +1956,21 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 		lastBackgroundTaskPresenterState = null;
 		lastBgCount = 0;
 		lastBgTaskCount = 0;
+		agentActivity.clear();
+		agentIdentities.clear();
+		state.tasks = [];
+		state.visible = true;
+		state.nextId = 1;
+		state.activeTaskId = null;
+	}
 
+	/** Restore tasks/widget state for the current session or switched session.
+	 * @param ctx - Active extension context
+	 * @returns Nothing
+	 */
+	function restoreSessionState(ctx: ExtensionContext): void {
+		resetSessionState();
+		syncTaskGroupStore(ctx);
 		// Restore meta state (visibility, nextId) from session entries
 		const entries = ctx.sessionManager.getEntries();
 		const stateEntry = entries
@@ -1947,14 +1991,11 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 		// Load tasks: prefer file store (shared mode), fall back to session entries
 		if (store.isShared) {
 			loadFromStore();
-
-			// Start watching for cross-session changes
 			store.watch(() => {
 				loadFromStore();
 				updateWidget(ctx);
 			});
 		} else if (stateEntry?.data?.tasks) {
-			// Session-only mode: restore from entries, migrating old schema
 			state.tasks = stateEntry.data.tasks.map((t) => ({
 				id: (t.id as string) ?? String(state.nextId++),
 				subject: (t.subject as string) ?? (t.title as string) ?? "Untitled",
@@ -1969,15 +2010,10 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 				createdAt: (t.createdAt as number) ?? Date.now(),
 				completedAt: t.completedAt as number | undefined,
 			}));
-			// Recalculate nextId
 			const maxId = state.tasks.reduce((max, t) => Math.max(max, Number(t.id) || 0), 0);
 			state.nextId = Math.max(state.nextId, maxId + 1);
 		}
 
-		// Clear orphaned tasks on startup: at session_start no agents are running,
-		// so any in_progress tasks are leftovers from a dead session.
-		// Also clear if all tasks are already completed — the 2s auto-clear timer
-		// from a previous turn may have been killed by an extension reload.
 		if (state.tasks.length > 0) {
 			const orphaned = state.tasks.filter((t) => t.status === "in_progress");
 			const allCompleted = state.tasks.every((t) => t.status === "completed");
@@ -1986,7 +2022,6 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 			}
 		}
 
-		// Clean up team directories older than 7 days
 		cleanupStaleTeams(teamName);
 
 		if (!isSubagent) {
@@ -2131,6 +2166,14 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 
 		updateWidget(ctx);
 		updateAgentBar(ctx);
+	}
+
+	pi.on("session_start", async (_event, ctx) => {
+		restoreSessionState(ctx);
+	});
+
+	pi.on("session_switch", async (_event, ctx) => {
+		restoreSessionState(ctx);
 	});
 
 	// Cleanup on session end
@@ -2150,6 +2193,7 @@ Before calling manage_tasks complete/update, call manage_tasks list first so ind
 		legacyInteropBridgeCleanup?.();
 		legacyInteropBridgeCleanup = undefined;
 		store.close();
+		if (!isSubagent) delete process.env.PI_TEAM_NAME;
 		persistState();
 	});
 }

--- a/extensions/tasks/extension.json
+++ b/extensions/tasks/extension.json
@@ -11,6 +11,7 @@
 			"before_agent_start",
 			"session_shutdown",
 			"session_start",
+			"session_switch",
 			"subagent_start",
 			"subagent_stop",
 			"subagent_tool_call",

--- a/extensions/tasks/index.ts
+++ b/extensions/tasks/index.ts
@@ -19,7 +19,6 @@
  * {@link registerTasksExtension}.  Domain logic lives in sibling modules.
  */
 
-import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerTasksExtension } from "./commands/register-tasks-extension.js";
 import { TaskListStore } from "./state/index.js";
@@ -31,7 +30,7 @@ export type { AgentIdentity } from "./agents/index.js";
 export { classifyAgent } from "./agents/index.js";
 export { _extractTasksFromText, escapeRegex, findCompletedTasks } from "./parsing/index.js";
 export type { Task, TaskComment, TaskStatus, TasksState } from "./state/index.js";
-export { shouldClearOnAgentEnd } from "./state/index.js";
+export { buildSessionTaskGroupName, shouldClearOnAgentEnd } from "./state/index.js";
 
 // ── Entry point ──────────────────────────────────────────────────────────────
 
@@ -42,16 +41,7 @@ export { shouldClearOnAgentEnd } from "./state/index.js";
  */
 export default function tasksExtension(pi: ExtensionAPI): void {
 	const isSubagent = process.env.PI_IS_SUBAGENT === "1";
-
-	// Auto-generate a shared task-group name so subagents can coordinate via a
-	// file-backed store. PI_TEAM_NAME stays as the env var for backward compatibility.
-	const teamName =
-		process.env.PI_TEAM_NAME ?? (isSubagent ? null : `task-group-${randomUUID().slice(0, 8)}`);
-	if (teamName && !process.env.PI_TEAM_NAME) {
-		// Set on process.env so child subagents inherit it automatically
-		process.env.PI_TEAM_NAME = teamName;
-	}
-
+	const teamName = isSubagent ? (process.env.PI_TEAM_NAME ?? null) : null;
 	const store = new TaskListStore(teamName);
 	registerTasksExtension(pi, store, teamName);
 }

--- a/extensions/tasks/state/index.ts
+++ b/extensions/tasks/state/index.ts
@@ -6,6 +6,7 @@
  * locking and `fs.watch`, and pure predicates that operate on task arrays.
  */
 
+import { createHash } from "node:crypto";
 import type { FSWatcher } from "node:fs";
 import {
 	existsSync,
@@ -38,6 +39,31 @@ export const TEAM_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Minimum width for side-by-side layout (tasks left, subagents right). */
 export const MIN_SIDE_BY_SIDE_WIDTH = 120;
+
+/** Prefix used for session-scoped shared task-group directories. */
+const SESSION_TASK_GROUP_PREFIX = "task-group";
+
+/**
+ * Build a stable task-group name for a session/cwd pair.
+ *
+ * Main sessions use this to isolate task boards per session while keeping the
+ * same group name when the user reopens the same session later. Subagents
+ * inherit the resolved name via `PI_TEAM_NAME`.
+ *
+ * @param sessionId - Current session identifier
+ * @param cwd - Current working directory for the session
+ * @returns Stable, filesystem-safe task-group name
+ */
+export function buildSessionTaskGroupName(sessionId: string, cwd: string): string {
+	const safeSessionId =
+		sessionId
+			.replace(/[^a-zA-Z0-9._-]/g, "_")
+			.replace(/_+/g, "_")
+			.replace(/^_+|_+$/g, "")
+			.slice(0, 24) || "session";
+	const digest = createHash("sha256").update(`${sessionId}:${cwd}`).digest("hex").slice(0, 12);
+	return `${SESSION_TASK_GROUP_PREFIX}-${safeSessionId}-${digest}`;
+}
 
 // ── Task Types ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- scope task-group storage by session ID and cwd instead of reusing a leaked `PI_TEAM_NAME`
- rebind the tasks store on `session_start` and `session_switch` so task boards stop bleeding across workspaces
- add a regression test covering session-scoped task groups and session switching

## Testing
- bun test extensions/__integration__/tasks-runtime.test.ts extensions/tasks/__tests__/state-transitions.test.ts extensions/tasks/__tests__/widget-subagents.test.ts
- bun run typecheck:extensions