### PR TITLE
fix(deps): support pi 0.61.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@dungle-scrubs/synapse": "0.1.6",
-        "@mariozechner/pi-coding-agent": "^0.60.0",
+        "@mariozechner/pi-coding-agent": "0.61.1",
         "@mariozechner/pi-tui": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
         "@sinclair/typebox": "0.34.48",
@@ -18,8 +18,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
-        "@mariozechner/pi-agent-core": "^0.60.0",
-        "@mariozechner/pi-ai": "^0.60.0",
+        "@mariozechner/pi-agent-core": "0.61.1",
+        "@mariozechner/pi-ai": "0.61.1",
         "@types/node": "25.2.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -29,7 +29,7 @@
     },
     "packages/tallow-tui": {
       "name": "@mariozechner/pi-tui",
-      "version": "0.60.0",
+      "version": "0.61.1",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
@@ -40,6 +40,7 @@
     },
   },
   "overrides": {
+    "@mariozechner/pi-tui": "workspace:*",
     "ajv": "8.18.0",
     "basic-ftp": "5.2.0",
     "fast-xml-parser": "5.3.6",
@@ -178,11 +179,11 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.60.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.60.0" } }, "sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.61.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.61.1" } }, "sha512-ELZsyx6INGBYXPAbYTAiRWtkmnwAlcXOOVPY434BE605TBdpzMrXF5gNckKdEyCCWYJiLzSKpHaAzWwB7Vx2nA=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.60.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.61.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-BOk8xwluIgauX93qgC9qyrWteKKnk6pNDM8szE1m/EJKMhcJ/jIJpgAUQgj4yXiwSMtcZm30h2Po97gqqXTIIg=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.60.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.60.0", "@mariozechner/pi-ai": "^0.60.0", "@mariozechner/pi-tui": "^0.60.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.61.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.61.1", "@mariozechner/pi-ai": "^0.61.1", "@mariozechner/pi-tui": "^0.61.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-w0QTn+LFFdyFhpaaYDOacGwBjW4MKYrl40b6LPfKDuVJ+9fDfHl3kWkbx6xJb9brk6M5lEFMheC82UIQdkeK3Q=="],
 
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@workspace:packages/tallow-tui"],
 

--- a/extensions/background-task-tool/index.ts
+++ b/extensions/background-task-tool/index.ts
@@ -1076,7 +1076,7 @@ export default function backgroundTasksExtension(pi: ExtensionAPI): void {
 
 						if (!expanded && truncated) {
 							lines.push(
-								formatPresentationText(theme, "hint", keyHint("expandTools", "to show more"))
+								formatPresentationText(theme, "hint", keyHint("app.tools.expand", "to show more"))
 							);
 						}
 					} else {

--- a/extensions/read-tool-enhanced/index.ts
+++ b/extensions/read-tool-enhanced/index.ts
@@ -489,7 +489,11 @@ export default function readSummary(pi: ExtensionAPI): void {
 				const left =
 					formatPresentationText(theme, "identity", icon) +
 					` ${formatPresentationText(theme, "identity", `skill: ${skillName}`)}`;
-				const right = formatPresentationText(theme, "hint", keyHint("expandTools", "to expand"));
+				const right = formatPresentationText(
+					theme,
+					"hint",
+					keyHint("app.tools.expand", "to expand")
+				);
 
 				return {
 					render(width: number): string[] {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 	"dependencies": {
 		"@clack/prompts": "^1.1.0",
 		"@dungle-scrubs/synapse": "0.1.6",
-		"@mariozechner/pi-coding-agent": "^0.60.0",
+		"@mariozechner/pi-coding-agent": "0.61.1",
 		"@mariozechner/pi-tui": "workspace:*",
 		"@opentelemetry/api": "^1.9.0",
 		"@sinclair/typebox": "0.34.48",
@@ -86,8 +86,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.2",
-		"@mariozechner/pi-agent-core": "^0.60.0",
-		"@mariozechner/pi-ai": "^0.60.0",
+		"@mariozechner/pi-agent-core": "0.61.1",
+		"@mariozechner/pi-ai": "0.61.1",
 		"@types/node": "25.2.3",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.4.0",
@@ -106,6 +106,7 @@
 		"url": "https://github.com/dungle-scrubs/tallow/issues"
 	},
 	"overrides": {
+		"@mariozechner/pi-tui": "workspace:*",
 		"ajv": "8.18.0",
 		"basic-ftp": "5.2.0",
 		"fast-xml-parser": "5.3.6",

--- a/packages/tallow-tui/package.json
+++ b/packages/tallow-tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mariozechner/pi-tui",
-	"version": "0.60.0",
+	"version": "0.61.1",
 	"private": true,
 	"description": "Tallow's TUI fork — customizable loader, rounded borders, which-key overlay",
 	"type": "module",

--- a/packages/tallow-tui/src/index.ts
+++ b/packages/tallow-tui/src/index.ts
@@ -50,7 +50,15 @@ export {
 	type EditorKeybindingsConfig,
 	EditorKeybindingsManager,
 	getEditorKeybindings,
+	getKeybindings,
+	type Keybinding,
+	type KeybindingDefinition,
+	type Keybindings,
+	type KeybindingsConfig,
+	KeybindingsManager,
 	setEditorKeybindings,
+	setKeybindings,
+	TUI_KEYBINDINGS,
 } from "./keybindings.js";
 // Keyboard input handling
 export {

--- a/packages/tallow-tui/src/keybindings.ts
+++ b/packages/tallow-tui/src/keybindings.ts
@@ -1,183 +1,473 @@
 import { type KeyId, matchesKey } from "./keys.js";
 
+/** Modern TUI keybinding identifiers. */
+export interface Keybindings {
+	"tui.editor.cursorDown": true;
+	"tui.editor.cursorLeft": true;
+	"tui.editor.cursorLineEnd": true;
+	"tui.editor.cursorLineStart": true;
+	"tui.editor.cursorRight": true;
+	"tui.editor.cursorUp": true;
+	"tui.editor.cursorWordLeft": true;
+	"tui.editor.cursorWordRight": true;
+	"tui.editor.deleteCharBackward": true;
+	"tui.editor.deleteCharForward": true;
+	"tui.editor.deleteToLineEnd": true;
+	"tui.editor.deleteToLineStart": true;
+	"tui.editor.deleteWordBackward": true;
+	"tui.editor.deleteWordForward": true;
+	"tui.editor.jumpBackward": true;
+	"tui.editor.jumpForward": true;
+	"tui.editor.pageDown": true;
+	"tui.editor.pageUp": true;
+	"tui.editor.undo": true;
+	"tui.editor.yank": true;
+	"tui.editor.yankPop": true;
+	"tui.input.copy": true;
+	"tui.input.newLine": true;
+	"tui.input.submit": true;
+	"tui.input.tab": true;
+	"tui.select.cancel": true;
+	"tui.select.confirm": true;
+	"tui.select.down": true;
+	"tui.select.pageDown": true;
+	"tui.select.pageUp": true;
+	"tui.select.up": true;
+}
+
+const LEGACY_TO_MODERN_KEYBINDINGS = {
+	copy: "tui.input.copy",
+	cursorDown: "tui.editor.cursorDown",
+	cursorLeft: "tui.editor.cursorLeft",
+	cursorLineEnd: "tui.editor.cursorLineEnd",
+	cursorLineStart: "tui.editor.cursorLineStart",
+	cursorRight: "tui.editor.cursorRight",
+	cursorUp: "tui.editor.cursorUp",
+	cursorWordLeft: "tui.editor.cursorWordLeft",
+	cursorWordRight: "tui.editor.cursorWordRight",
+	deleteCharBackward: "tui.editor.deleteCharBackward",
+	deleteCharForward: "tui.editor.deleteCharForward",
+	deleteSession: "app.session.delete",
+	deleteSessionNoninvasive: "app.session.deleteNoninvasive",
+	deleteToLineEnd: "tui.editor.deleteToLineEnd",
+	deleteToLineStart: "tui.editor.deleteToLineStart",
+	deleteWordBackward: "tui.editor.deleteWordBackward",
+	deleteWordForward: "tui.editor.deleteWordForward",
+	expandTools: "app.tools.expand",
+	jumpBackward: "tui.editor.jumpBackward",
+	jumpForward: "tui.editor.jumpForward",
+	newLine: "tui.input.newLine",
+	pageDown: "tui.editor.pageDown",
+	pageUp: "tui.editor.pageUp",
+	renameSession: "app.session.rename",
+	selectCancel: "tui.select.cancel",
+	selectConfirm: "tui.select.confirm",
+	selectDown: "tui.select.down",
+	selectPageDown: "tui.select.pageDown",
+	selectPageUp: "tui.select.pageUp",
+	selectUp: "tui.select.up",
+	submit: "tui.input.submit",
+	tab: "tui.input.tab",
+	toggleSessionPath: "app.session.togglePath",
+	toggleSessionSort: "app.session.toggleSort",
+	undo: "tui.editor.undo",
+	yank: "tui.editor.yank",
+	yankPop: "tui.editor.yankPop",
+} as const;
+
+/** Backward-compatible legacy editor actions. */
+export type EditorAction = keyof typeof LEGACY_TO_MODERN_KEYBINDINGS;
+
+/** Modern keybinding identifier. */
+export type Keybinding = keyof Keybindings | EditorAction;
+
+/** Single keybinding definition with defaults and UI help text. */
+export interface KeybindingDefinition {
+	readonly defaultKeys: KeyId | readonly KeyId[];
+	readonly description: string;
+}
+
+/** User-provided keybinding overrides. */
+export type KeybindingsConfig = Partial<Record<Keybinding, KeyId | readonly KeyId[]>>;
+
+/** Backward-compatible legacy editor config. */
+export type EditorKeybindingsConfig = Partial<Record<EditorAction, KeyId | readonly KeyId[]>>;
+
+/** Default legacy editor keybindings preserved for compatibility. */
+export const DEFAULT_EDITOR_KEYBINDINGS: Required<Record<EditorAction, KeyId | readonly KeyId[]>> =
+	{
+		copy: "ctrl+shift+c",
+		cursorDown: "down",
+		cursorLeft: ["left", "ctrl+b"],
+		cursorLineEnd: ["end", "ctrl+e"],
+		cursorLineStart: ["home", "ctrl+a"],
+		cursorRight: ["right", "ctrl+f"],
+		cursorUp: "up",
+		cursorWordLeft: ["alt+left", "ctrl+left", "alt+b"],
+		cursorWordRight: ["alt+right", "ctrl+right", "alt+f"],
+		deleteCharBackward: "backspace",
+		deleteCharForward: ["delete", "ctrl+d"],
+		deleteSession: "ctrl+d",
+		deleteSessionNoninvasive: "ctrl+backspace",
+		deleteToLineEnd: "ctrl+k",
+		deleteToLineStart: "ctrl+u",
+		deleteWordBackward: ["ctrl+w", "alt+backspace"],
+		deleteWordForward: ["alt+d", "alt+delete"],
+		expandTools: "ctrl+o",
+		jumpBackward: "ctrl+alt+]",
+		jumpForward: "ctrl+]",
+		newLine: "shift+enter",
+		pageDown: "pageDown",
+		pageUp: "pageUp",
+		renameSession: "ctrl+r",
+		selectCancel: ["escape", "ctrl+c"],
+		selectConfirm: "enter",
+		selectDown: "down",
+		selectPageDown: "pageDown",
+		selectPageUp: "pageUp",
+		selectUp: "up",
+		submit: "enter",
+		tab: "tab",
+		toggleSessionPath: "ctrl+p",
+		toggleSessionSort: "ctrl+s",
+		undo: "ctrl+-",
+		yank: "ctrl+y",
+		yankPop: "alt+y",
+	};
+
+/** Modern TUI keybinding definitions consumed by pi-coding-agent 0.61+. */
+export const TUI_KEYBINDINGS = {
+	"tui.editor.cursorDown": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorDown,
+		description: "Move cursor down",
+	},
+	"tui.editor.cursorLeft": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorLeft,
+		description: "Move cursor left",
+	},
+	"tui.editor.cursorLineEnd": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorLineEnd,
+		description: "Move to line end",
+	},
+	"tui.editor.cursorLineStart": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorLineStart,
+		description: "Move to line start",
+	},
+	"tui.editor.cursorRight": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorRight,
+		description: "Move cursor right",
+	},
+	"tui.editor.cursorUp": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorUp,
+		description: "Move cursor up",
+	},
+	"tui.editor.cursorWordLeft": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorWordLeft,
+		description: "Move cursor word left",
+	},
+	"tui.editor.cursorWordRight": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.cursorWordRight,
+		description: "Move cursor word right",
+	},
+	"tui.editor.deleteCharBackward": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.deleteCharBackward,
+		description: "Delete character backward",
+	},
+	"tui.editor.deleteCharForward": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.deleteCharForward,
+		description: "Delete character forward",
+	},
+	"tui.editor.deleteToLineEnd": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.deleteToLineEnd,
+		description: "Delete to line end",
+	},
+	"tui.editor.deleteToLineStart": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.deleteToLineStart,
+		description: "Delete to line start",
+	},
+	"tui.editor.deleteWordBackward": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.deleteWordBackward,
+		description: "Delete word backward",
+	},
+	"tui.editor.deleteWordForward": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.deleteWordForward,
+		description: "Delete word forward",
+	},
+	"tui.editor.jumpBackward": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.jumpBackward,
+		description: "Jump backward to character",
+	},
+	"tui.editor.jumpForward": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.jumpForward,
+		description: "Jump forward to character",
+	},
+	"tui.editor.pageDown": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.pageDown,
+		description: "Page down",
+	},
+	"tui.editor.pageUp": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.pageUp,
+		description: "Page up",
+	},
+	"tui.editor.undo": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.undo,
+		description: "Undo",
+	},
+	"tui.editor.yank": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.yank,
+		description: "Yank",
+	},
+	"tui.editor.yankPop": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.yankPop,
+		description: "Yank pop",
+	},
+	"tui.input.copy": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.copy,
+		description: "Copy selection",
+	},
+	"tui.input.newLine": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.newLine,
+		description: "Insert newline",
+	},
+	"tui.input.submit": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.submit,
+		description: "Submit input",
+	},
+	"tui.input.tab": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.tab,
+		description: "Tab / autocomplete",
+	},
+	"tui.select.cancel": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.selectCancel,
+		description: "Cancel selection",
+	},
+	"tui.select.confirm": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.selectConfirm,
+		description: "Confirm selection",
+	},
+	"tui.select.down": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.selectDown,
+		description: "Move selection down",
+	},
+	"tui.select.pageDown": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.selectPageDown,
+		description: "Selection page down",
+	},
+	"tui.select.pageUp": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.selectPageUp,
+		description: "Selection page up",
+	},
+	"tui.select.up": {
+		defaultKeys: DEFAULT_EDITOR_KEYBINDINGS.selectUp,
+		description: "Move selection up",
+	},
+} as const satisfies Record<keyof Keybindings, KeybindingDefinition>;
+
+type ModernKeybinding = keyof Keybindings;
+
+type NormalizedKeybindingsConfig = Partial<Record<ModernKeybinding, readonly KeyId[]>>;
+
 /**
- * Editor actions that can be bound to keys.
+ * Check whether a keybinding name is a supported modern identifier.
+ *
+ * @param {string} keybinding - Candidate keybinding name.
+ * @returns {keybinding is ModernKeybinding} True when the keybinding exists.
  */
-export type EditorAction =
-	// Cursor movement
-	| "cursorUp"
-	| "cursorDown"
-	| "cursorLeft"
-	| "cursorRight"
-	| "cursorWordLeft"
-	| "cursorWordRight"
-	| "cursorLineStart"
-	| "cursorLineEnd"
-	| "jumpForward"
-	| "jumpBackward"
-	| "pageUp"
-	| "pageDown"
-	// Deletion
-	| "deleteCharBackward"
-	| "deleteCharForward"
-	| "deleteWordBackward"
-	| "deleteWordForward"
-	| "deleteToLineStart"
-	| "deleteToLineEnd"
-	// Text input
-	| "newLine"
-	| "submit"
-	| "tab"
-	// Selection/autocomplete
-	| "selectUp"
-	| "selectDown"
-	| "selectPageUp"
-	| "selectPageDown"
-	| "selectConfirm"
-	| "selectCancel"
-	// Clipboard
-	| "copy"
-	// Kill ring
-	| "yank"
-	| "yankPop"
-	// Undo
-	| "undo"
-	// Tool output
-	| "expandTools"
-	// Session
-	| "toggleSessionPath"
-	| "toggleSessionSort"
-	| "renameSession"
-	| "deleteSession"
-	| "deleteSessionNoninvasive";
-
-// Re-export KeyId from keys.ts
-export type { KeyId };
+function isModernKeybinding(keybinding: string): keybinding is ModernKeybinding {
+	return keybinding in TUI_KEYBINDINGS;
+}
 
 /**
- * Editor keybindings configuration.
+ * Normalize a legacy or modern keybinding identifier to the modern name.
+ *
+ * @param {Keybinding} keybinding - Keybinding identifier to normalize.
+ * @returns {ModernKeybinding | null} Modern keybinding or null when unsupported.
  */
-export type EditorKeybindingsConfig = {
-	[K in EditorAction]?: KeyId | KeyId[];
-};
-
-/**
- * Default editor keybindings.
- */
-export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
-	// Cursor movement
-	cursorUp: "up",
-	cursorDown: "down",
-	cursorLeft: ["left", "ctrl+b"],
-	cursorRight: ["right", "ctrl+f"],
-	cursorWordLeft: ["alt+left", "ctrl+left", "alt+b"],
-	cursorWordRight: ["alt+right", "ctrl+right", "alt+f"],
-	cursorLineStart: ["home", "ctrl+a"],
-	cursorLineEnd: ["end", "ctrl+e"],
-	jumpForward: "ctrl+]",
-	jumpBackward: "ctrl+alt+]",
-	pageUp: "pageUp",
-	pageDown: "pageDown",
-	// Deletion
-	deleteCharBackward: "backspace",
-	deleteCharForward: ["delete", "ctrl+d"],
-	deleteWordBackward: ["ctrl+w", "alt+backspace"],
-	deleteWordForward: ["alt+d", "alt+delete"],
-	deleteToLineStart: "ctrl+u",
-	deleteToLineEnd: "ctrl+k",
-	// Text input
-	newLine: "shift+enter",
-	submit: "enter",
-	tab: "tab",
-	// Selection/autocomplete
-	selectUp: "up",
-	selectDown: "down",
-	selectPageUp: "pageUp",
-	selectPageDown: "pageDown",
-	selectConfirm: "enter",
-	selectCancel: ["escape", "ctrl+c"],
-	// Clipboard (ctrl+c in editor is handled as selectCancel/interrupt, not copy)
-	copy: "ctrl+shift+c",
-	// Kill ring
-	yank: "ctrl+y",
-	yankPop: "alt+y",
-	// Undo
-	undo: "ctrl+-",
-	// Tool output
-	expandTools: "ctrl+o",
-	// Session
-	toggleSessionPath: "ctrl+p",
-	toggleSessionSort: "ctrl+s",
-	renameSession: "ctrl+r",
-	deleteSession: "ctrl+d",
-	deleteSessionNoninvasive: "ctrl+backspace",
-};
-
-/**
- * Manages keybindings for the editor.
- */
-export class EditorKeybindingsManager {
-	private actionToKeys: Map<EditorAction, KeyId[]>;
-
-	constructor(config: EditorKeybindingsConfig = {}) {
-		this.actionToKeys = new Map();
-		this.buildMaps(config);
+function normalizeKeybinding(keybinding: Keybinding): ModernKeybinding | null {
+	if (isModernKeybinding(keybinding)) {
+		return keybinding;
 	}
 
-	private buildMaps(config: EditorKeybindingsConfig): void {
-		this.actionToKeys.clear();
+	const normalized = LEGACY_TO_MODERN_KEYBINDINGS[keybinding as EditorAction];
+	return normalized && isModernKeybinding(normalized) ? normalized : null;
+}
 
-		// Start with defaults
-		for (const [action, keys] of Object.entries(DEFAULT_EDITOR_KEYBINDINGS)) {
-			const keyArray = Array.isArray(keys) ? keys : [keys];
-			this.actionToKeys.set(action as EditorAction, [...keyArray]);
-		}
+/**
+ * Convert a raw keybinding value into an array form.
+ *
+ * @param {KeyId | readonly KeyId[]} value - Raw keybinding value.
+ * @returns {readonly KeyId[]} Normalized key array.
+ */
+function normalizeKeyArray(value: KeyId | readonly KeyId[]): readonly KeyId[] {
+	return Array.isArray(value) ? [...value] : [value as KeyId];
+}
 
-		// Override with user config
-		for (const [action, keys] of Object.entries(config)) {
-			if (keys === undefined) continue;
-			const keyArray = Array.isArray(keys) ? keys : [keys];
-			this.actionToKeys.set(action as EditorAction, keyArray);
+/**
+ * Normalize user bindings to modern identifiers and array values.
+ *
+ * @param {KeybindingsConfig} userBindings - Raw user bindings.
+ * @returns {NormalizedKeybindingsConfig} Normalized modern binding map.
+ */
+function normalizeUserBindings(userBindings: KeybindingsConfig): NormalizedKeybindingsConfig {
+	const normalized: NormalizedKeybindingsConfig = {};
+
+	for (const [rawKey, rawValue] of Object.entries(userBindings)) {
+		if (rawValue === undefined) continue;
+
+		const key = rawKey as Keybinding;
+		const modernKey = normalizeKeybinding(key);
+		if (!modernKey) continue;
+		if (key !== modernKey && userBindings[modernKey] !== undefined) continue;
+
+		normalized[modernKey] = [...normalizeKeyArray(rawValue)];
+	}
+
+	return normalized;
+}
+
+/**
+ * Keybinding manager compatible with pi-tui 0.61+ while preserving legacy names.
+ */
+export class KeybindingsManager {
+	private readonly definitions: Readonly<Record<ModernKeybinding, KeybindingDefinition>>;
+	private readonly resolvedKeys = new Map<ModernKeybinding, KeyId[]>();
+	private userBindings: NormalizedKeybindingsConfig;
+
+	/**
+	 * Create a keybindings manager.
+	 *
+	 * @param {Readonly<Record<ModernKeybinding, KeybindingDefinition>>} definitions - Keybinding definitions.
+	 * @param {KeybindingsConfig} userBindings - Optional user overrides.
+	 */
+	constructor(
+		definitions: Readonly<Record<ModernKeybinding, KeybindingDefinition>> = TUI_KEYBINDINGS,
+		userBindings: KeybindingsConfig = {}
+	) {
+		this.definitions = definitions;
+		this.userBindings = normalizeUserBindings(userBindings);
+		this.rebuild();
+	}
+
+	/**
+	 * Rebuild resolved bindings from defaults plus user overrides.
+	 *
+	 * @returns {void} Nothing.
+	 */
+	private rebuild(): void {
+		this.resolvedKeys.clear();
+
+		for (const [keybinding, definition] of Object.entries(this.definitions)) {
+			const modernKey = keybinding as ModernKeybinding;
+			const override = this.userBindings[modernKey];
+			const keys = override ?? normalizeKeyArray(definition.defaultKeys);
+			this.resolvedKeys.set(modernKey, [...keys]);
 		}
 	}
 
 	/**
-	 * Check if input matches a specific action.
+	 * Check whether input matches a keybinding.
+	 *
+	 * @param {string} data - Raw terminal input.
+	 * @param {Keybinding} keybinding - Keybinding identifier.
+	 * @returns {boolean} True when the input matches.
 	 */
-	matches(data: string, action: EditorAction): boolean {
-		const keys = this.actionToKeys.get(action);
-		if (!keys) return false;
-		for (const key of keys) {
+	matches(data: string, keybinding: Keybinding): boolean {
+		const modernKey = normalizeKeybinding(keybinding);
+		if (!modernKey) return false;
+
+		for (const key of this.resolvedKeys.get(modernKey) ?? []) {
 			if (matchesKey(data, key)) return true;
 		}
 		return false;
 	}
 
 	/**
-	 * Get keys bound to an action.
+	 * Get the keys currently bound to a keybinding.
+	 *
+	 * @param {Keybinding} keybinding - Keybinding identifier.
+	 * @returns {KeyId[]} Resolved key list.
 	 */
-	getKeys(action: EditorAction): KeyId[] {
-		return this.actionToKeys.get(action) ?? [];
+	getKeys(keybinding: Keybinding): KeyId[] {
+		const modernKey = normalizeKeybinding(keybinding);
+		return modernKey ? [...(this.resolvedKeys.get(modernKey) ?? [])] : [];
 	}
 
 	/**
-	 * Update configuration.
+	 * Replace user bindings and rebuild the resolved map.
+	 *
+	 * @param {KeybindingsConfig} userBindings - New user bindings.
+	 * @returns {void} Nothing.
 	 */
-	setConfig(config: EditorKeybindingsConfig): void {
-		this.buildMaps(config);
+	setUserBindings(userBindings: KeybindingsConfig): void {
+		this.userBindings = normalizeUserBindings(userBindings);
+		this.rebuild();
+	}
+
+	/**
+	 * Get the fully resolved modern keybinding config.
+	 *
+	 * @returns {NormalizedKeybindingsConfig} Resolved keybinding config.
+	 */
+	getResolvedBindings(): NormalizedKeybindingsConfig {
+		const resolved: NormalizedKeybindingsConfig = {};
+		for (const [keybinding, keys] of this.resolvedKeys.entries()) {
+			resolved[keybinding] = [...keys];
+		}
+		return resolved;
 	}
 }
 
-// Global instance
-let globalEditorKeybindings: EditorKeybindingsManager | null = null;
+/** Backward-compatible alias for legacy callers. */
+export class EditorKeybindingsManager extends KeybindingsManager {
+	/**
+	 * Create a legacy editor keybindings manager.
+	 *
+	 * @param {EditorKeybindingsConfig} config - Legacy editor keybinding overrides.
+	 */
+	constructor(config: EditorKeybindingsConfig = {}) {
+		super(TUI_KEYBINDINGS, config);
+	}
+}
 
+let globalKeybindings: KeybindingsManager | null = null;
+
+/**
+ * Get the shared keybindings manager.
+ *
+ * @returns {KeybindingsManager} Shared keybindings manager.
+ */
+export function getKeybindings(): KeybindingsManager {
+	if (!globalKeybindings) {
+		globalKeybindings = new EditorKeybindingsManager();
+	}
+	return globalKeybindings;
+}
+
+/**
+ * Replace the shared keybindings manager.
+ *
+ * @param {KeybindingsManager} manager - Keybindings manager to install.
+ * @returns {void} Nothing.
+ */
+export function setKeybindings(manager: KeybindingsManager): void {
+	globalKeybindings = manager;
+}
+
+/**
+ * Get the shared legacy editor keybindings manager.
+ *
+ * @returns {EditorKeybindingsManager} Shared legacy-compatible manager.
+ */
 export function getEditorKeybindings(): EditorKeybindingsManager {
-	if (!globalEditorKeybindings) {
-		globalEditorKeybindings = new EditorKeybindingsManager();
-	}
-	return globalEditorKeybindings;
+	return getKeybindings() as EditorKeybindingsManager;
 }
 
+/**
+ * Replace the shared legacy editor keybindings manager.
+ *
+ * @param {EditorKeybindingsManager} manager - Legacy keybindings manager.
+ * @returns {void} Nothing.
+ */
 export function setEditorKeybindings(manager: EditorKeybindingsManager): void {
-	globalEditorKeybindings = manager;
+	setKeybindings(manager);
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2825,16 +2825,16 @@ function ensureTallowHome(startupProfile: TallowStartupProfile): void {
  * Never bind anything to ctrl+m — it will intercept Enter.
  *
  * Remaps:
- *   cycleModelForward:  ctrl+p → unbound (use ctrl+l model selector instead)
- *   cycleModelBackward: shift+ctrl+p → unbound
- *   toggleSessionSort:  ctrl+s → unbound
- *   toggleSessionPath:  ctrl+p → unbound
+ *   app.model.cycleForward:  ctrl+p → unbound (use ctrl+l model selector instead)
+ *   app.model.cycleBackward: shift+ctrl+p → unbound
+ *   app.session.toggleSort:  ctrl+s → unbound
+ *   app.session.togglePath:  ctrl+p → unbound
  */
 const TALLOW_KEYBINDINGS: Record<string, string | string[]> = {
-	cycleModelForward: [],
-	cycleModelBackward: [],
-	toggleSessionSort: [],
-	toggleSessionPath: [],
+	"app.model.cycleBackward": [],
+	"app.model.cycleForward": [],
+	"app.session.togglePath": [],
+	"app.session.toggleSort": [],
 };
 
 /**


### PR DESCRIPTION
## Summary
- bump the pi packages to 0.61.1 and sync the forked pi-tui version
- force pi-coding-agent's transitive pi-tui dependency to resolve to the workspace fork
- add the pi-tui 0.61 keybindings API while keeping tallow's legacy aliases working

## Changes Made
- export the 0.61 keybinding surface from packages/tallow-tui and map old names like `expandTools` to the new IDs
- update tallow keybinding overrides and tool hints to use the new app-scoped key names
- regenerate the lockfile against the new dependency set

## Testing
- `bun run build`
- `env -u TALLOW_AUTO_REBUILD_ATTEMPTED -u TALLOW_DISABLE_AUTO_REBUILD bun test`

Closes #208
