### PR TITLE
fix(welcome-screen): target headerContainer children instead of TUI root

### DIFF
--- a/extensions/welcome-screen/index.ts
+++ b/extensions/welcome-screen/index.ts
@@ -158,9 +158,11 @@ export default function welcomeScreenExtension(pi: ExtensionAPI): void {
 		// headerContainer is the first child of the root TUI component.
 		queueMicrotask(() => {
 			if (!tuiRef) return;
-			const headerContainer = (tuiRef as unknown as Record<string, unknown>).children as
-				| { length: number }
+			const tuiChildren = (tuiRef as unknown as Record<string, unknown>).children as
+				| Array<Record<string, unknown>>
 				| undefined;
+			// headerContainer is the first child of the TUI root
+			const headerContainer = tuiChildren?.[0]?.children as { length: number } | undefined;
 			if (headerContainer && headerContainer.length > 2) {
 				// Keep [0]=Spacer and [1]=custom header, drop the rest (bottom spacer + changelog)
 				headerContainer.length = 2;


### PR DESCRIPTION
## Summary
- Fix queueMicrotask cleanup targeting the wrong children array, destroying the TUI on startup

## Changes Made
- Navigate to `tuiRef.children[0].children` (headerContainer) instead of `tuiRef.children` (TUI root) before truncating changelog entries

## Testing
- Unit tests pass (`bun test extensions/welcome-screen`)
- E2E command registration passes (`node tests/e2e-commands.mjs`)
- Typecheck clean (core + extensions)