### PR TITLE
fix(tui): don't auto-enable mouse tracking on setup

### DIFF
--- a/packages/tallow-tui/src/terminal.ts
+++ b/packages/tallow-tui/src/terminal.ts
@@ -109,10 +109,10 @@ export class ProcessTerminal implements Terminal {
 			process.kill(process.pid, "SIGWINCH");
 		}
 
-		// Enable mouse tracking so scroll events reach the app.
-		// Without this, tmux `mouse on` enters copy-mode on scroll instead
-		// of forwarding events to the application.
-		this.enableMouse();
+		// Mouse tracking is available (enableMouse/disableMouse) but NOT
+		// enabled by default. Capturing mouse events without scroll handling
+		// breaks native terminal scroll and text selection. Enable only after
+		// wiring onMouse scroll behavior in the consumer.
 
 		// Enable keyboard protocol for modified key detection.
 		// tmux doesn't support the Kitty keyboard protocol but does support xterm's


### PR DESCRIPTION
## Summary

Reverts the auto-enable of mouse tracking from `ProcessTerminal.setup()` introduced in #224. Enabling mouse mode 1000 without scroll handling breaks native terminal scroll and text selection — events are captured by the app and silently discarded.

## Changes Made

- Removed `this.enableMouse()` from `ProcessTerminal.setup()`
- Mouse infrastructure (parsing, callbacks, enable/disable methods) remains intact for when scroll handling is wired up

## Testing

- All 248 TUI tests pass
- Manual: mouse scroll and text selection work again