### PR TITLE
fix(tui): enable mouse tracking only inside tmux

### DIFF
--- a/packages/tallow-tui/src/terminal.ts
+++ b/packages/tallow-tui/src/terminal.ts
@@ -109,10 +109,13 @@ export class ProcessTerminal implements Terminal {
 			process.kill(process.pid, "SIGWINCH");
 		}
 
-		// Mouse tracking is available (enableMouse/disableMouse) but NOT
-		// enabled by default. Capturing mouse events without scroll handling
-		// breaks native terminal scroll and text selection. Enable only after
-		// wiring onMouse scroll behavior in the consumer.
+		// Enable mouse tracking inside tmux so scroll events are forwarded
+		// to the app instead of triggering tmux copy-mode. Outside tmux the
+		// terminal emulator handles mouse natively (scroll, selection) and
+		// enabling tracking would steal those events.
+		if (process.env.TMUX) {
+			this.enableMouse();
+		}
 
 		// Enable keyboard protocol for modified key detection.
 		// tmux doesn't support the Kitty keyboard protocol but does support xterm's


### PR DESCRIPTION
## Summary

Fixes the tmux copy-mode trap without breaking mouse behavior outside tmux.

**The problem:** tmux `mouse on` enters copy-mode when the app doesn't claim mouse events. Once in copy-mode, Cmd+Down doesn't work and typing goes to copy-mode keybindings instead of tallow. The user is stuck.

**Previous attempt (#224):** Enabled mouse tracking unconditionally → broke native scroll and text selection outside tmux → reverted in #225.

**This fix:** Enable mouse tracking only when `TMUX` env is set. Inside tmux, scroll events are forwarded to the app (consumed, no copy-mode trap). Outside tmux, the terminal handles mouse natively.

## Testing

- 248 TUI tests pass
- Manual: tmux no longer enters copy-mode on scroll; outside tmux, scroll and selection work normally