### PR TITLE
ci: reduce github actions frequency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,7 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  schedule:
-    # Weekly deep scan — catches issues in code that didn't change in a PR
-    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/dep-check.yml
+++ b/.github/workflows/dep-check.yml
@@ -2,8 +2,8 @@ name: Dependency Check
 
 on:
   schedule:
-    # Daily at 08:00 UTC
-    - cron: "0 8 * * *"
+    # Weekly on Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/matrix-refresh.yml
+++ b/.github/workflows/matrix-refresh.yml
@@ -1,9 +1,6 @@
 name: Model Matrix Refresh
 
 on:
-  schedule:
-    # Weekly on Monday at 09:00 UTC
-    - cron: "0 9 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Reduces the noise and cost of automated runs on `main` and scheduled jobs.