### PR TITLE
fix: correct claude-sonnet-4-6 context window from 1M to 200k

### DIFF
--- a/src/__tests__/model-metadata-overrides.test.ts
+++ b/src/__tests__/model-metadata-overrides.test.ts
@@ -60,4 +60,22 @@ describe("applyKnownModelMetadataOverrides", () => {
 		expect(applied).toBe(0);
 		expect(codex.contextWindow).toBe(1_000_000);
 	});
+
+	it("corrects claude-sonnet-4-6 from 1M to 200k for anthropic and opencode providers", () => {
+		const anthropic = cloneBuiltInModel("anthropic", "claude-sonnet-4-6");
+		const opencode = cloneBuiltInModel("opencode", "claude-sonnet-4-6");
+		const antigravity = cloneBuiltInModel("google-antigravity", "claude-sonnet-4-6");
+		const registry = createRegistry([anthropic, opencode, antigravity]);
+
+		// Only patch entries that still carry the stale 1M value
+		const staleCount = [anthropic, opencode].filter((m) => m.contextWindow === 1_000_000).length;
+
+		const applied = applyKnownModelMetadataOverrides(registry);
+
+		expect(applied).toBe(staleCount);
+		expect(anthropic.contextWindow).toBe(200_000);
+		expect(opencode.contextWindow).toBe(200_000);
+		// google-antigravity already has 200k — never touched
+		expect(antigravity.contextWindow).toBe(200_000);
+	});
 });

--- a/src/model-metadata-overrides.ts
+++ b/src/model-metadata-overrides.ts
@@ -1,15 +1,34 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 
-const KNOWN_CONTEXT_WINDOW_OVERRIDES = {
+/** { stale: the wrong value in the registry, correct: the real value } */
+interface ContextWindowCorrection {
+	readonly stale: number;
+	readonly correct: number;
+}
+
+/**
+ * Per-provider, per-model corrections for known stale context window values in
+ * the upstream pi-ai registry. Each entry is only applied when the registry
+ * still carries the known wrong `stale` value, so explicit user `models.json`
+ * overrides always win.
+ */
+const KNOWN_CONTEXT_WINDOW_OVERRIDES: Record<string, Record<string, ContextWindowCorrection>> = {
+	// gpt-5.4 was shipped with a 272k window; the real documented limit is 1M.
 	openai: {
-		"gpt-5.4": 1_000_000,
+		"gpt-5.4": { stale: 272_000, correct: 1_000_000 },
 	},
 	"openai-codex": {
-		"gpt-5.4": 1_000_000,
+		"gpt-5.4": { stale: 272_000, correct: 1_000_000 },
 	},
-} as const;
-
-const STALE_CONTEXT_WINDOW = 272_000;
+	// claude-sonnet-4-6 is registered at 1M for the anthropic and opencode
+	// providers, but the actual limit for standard/Max accounts is 200k.
+	anthropic: {
+		"claude-sonnet-4-6": { stale: 1_000_000, correct: 200_000 },
+	},
+	opencode: {
+		"claude-sonnet-4-6": { stale: 1_000_000, correct: 200_000 },
+	},
+};
 
 interface ModelRegistryLike {
 	getAll(): Model<Api>[];
@@ -18,11 +37,8 @@ interface ModelRegistryLike {
 /**
  * Correct known stale upstream model metadata without clobbering explicit user overrides.
  *
- * The upstream pi-ai registry currently ships `gpt-5.4` with a 272k context
- * window for the OpenAI and OpenAI Codex providers, while current OpenAI docs
- * advertise a 1M context window. User `models.json` overrides should continue
- * to win, so this patch only rewrites entries that still carry the known stale
- * 272k value.
+ * Each correction is only applied when the registry still carries the known
+ * wrong `stale` value. User `models.json` overrides continue to win.
  *
  * @param modelRegistry - Registry containing built-in and user-overridden models
  * @returns Number of models patched in place
@@ -31,15 +47,14 @@ export function applyKnownModelMetadataOverrides(modelRegistry: ModelRegistryLik
 	let applied = 0;
 
 	for (const model of modelRegistry.getAll()) {
-		const providerOverrides =
-			KNOWN_CONTEXT_WINDOW_OVERRIDES[model.provider as keyof typeof KNOWN_CONTEXT_WINDOW_OVERRIDES];
+		const providerOverrides = KNOWN_CONTEXT_WINDOW_OVERRIDES[model.provider];
 		if (!providerOverrides) continue;
 
-		const contextWindow = providerOverrides[model.id as keyof typeof providerOverrides];
-		if (!contextWindow) continue;
-		if (model.contextWindow !== STALE_CONTEXT_WINDOW) continue;
+		const correction = providerOverrides[model.id];
+		if (!correction) continue;
+		if (model.contextWindow !== correction.stale) continue;
 
-		model.contextWindow = contextWindow;
+		model.contextWindow = correction.correct;
 		applied += 1;
 	}
 


### PR DESCRIPTION
pi-ai registry ships claude-sonnet-4-6 at 1_000_000 for the anthropic and opencode providers. The actual limit for standard/Max accounts is 200k. Add corrections using the existing override mechanism.

Also refactor `KNOWN_CONTEXT_WINDOW_OVERRIDES` from a flat value map to `{ stale, correct }` pairs so each correction can guard against its own specific wrong value rather than sharing a single global stale constant.