### PR TITLE
fix: resolve extension load failures on fresh install and bump pi deps to 0.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **packaging:** fix 3 bundled extensions failing on fresh install — `background-task-tool`,
+  `lsp`, and `teams-tool` imported from unpublished `src/` paths; moved to `runtime/` wrappers
+- **packaging:** move `vscode-languageserver-protocol` from devDependencies to dependencies
+  so the `lsp` extension loads on fresh installs
+- **deps:** bump `@mariozechner/pi-coding-agent`, `pi-agent-core`, and `pi-ai` from 0.62.0
+  to 0.64.0 — adapt to `ModelRegistry.create()` factory and `getApiKeyForProvider()` rename
+- **edit-tool:** propagate upstream `prepareArguments` normalization so old-format
+  `{oldText, newText}` params still work after pi 0.64.0 schema change
+
 ## [0.8.27](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.8.26...tallow-v0.8.27) (2026-03-21)
 
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@dungle-scrubs/synapse": "0.1.8",
-        "@mariozechner/pi-coding-agent": "^0.62.0",
+        "@mariozechner/pi-coding-agent": "^0.64.0",
         "@mariozechner/pi-tui": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
         "@sinclair/typebox": "0.34.48",
@@ -15,21 +15,21 @@
         "commander": "^14.0.3",
         "unpdf": "^1.4.0",
         "vscode-jsonrpc": "8.2.1",
+        "vscode-languageserver-protocol": "3.17.5",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
-        "@mariozechner/pi-agent-core": "^0.62.0",
-        "@mariozechner/pi-ai": "^0.62.0",
+        "@mariozechner/pi-agent-core": "^0.64.0",
+        "@mariozechner/pi-ai": "^0.64.0",
         "@types/node": "25.2.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "typescript": "^5.9.3",
-        "vscode-languageserver-protocol": "3.17.5",
       },
     },
     "packages/tallow-tui": {
       "name": "@mariozechner/pi-tui",
-      "version": "0.61.1",
+      "version": "0.62.0",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
@@ -179,11 +179,11 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.62.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.62.0" } }, "sha512-SBjqgDrgKOaC+IGzFGB3jXQErv9H1QMYnWFvUg6ra6dG0ZgWFBUZb6unidngWLsmaxSDWes6KeKiVFMsr2VSEQ=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.64.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.64.0" } }, "sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.62.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-mJgryZ5RgBQG++tiETMtCQQJoH2MAhKetCfqI98NMvGydu7L9x2qC2JekQlRaAgIlTgv4MRH1UXHMEs4UweE/Q=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.64.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.62.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.62.0", "@mariozechner/pi-ai": "^0.62.0", "@mariozechner/pi-tui": "^0.62.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-f1NnExqsHuA6w8UVlBtPsvTBhdkMc0h1JD9SzGCdWTLou5GHJr2JIP6DlwV9IKWAnM+sAelaoFez+14wLP2zOQ=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.64.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.64.0", "@mariozechner/pi-ai": "^0.64.0", "@mariozechner/pi-tui": "^0.64.0", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Q4tcqSqFGQtOgCtRyIp1D80Nv2if13Q2pfbnrOlaT/mix90mLcZGML9jKVnT1jGSy5GMYudU1HsS7cx53kxb0g=="],
 
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@workspace:packages/tallow-tui"],
 

--- a/extensions/_shared/pid-registry.ts
+++ b/extensions/_shared/pid-registry.ts
@@ -13,17 +13,17 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
-	createRuntimePathProvider,
-	type RuntimePathProvider,
-} from "../../runtime/runtime-path-provider.js";
-import {
 	isPidEntry,
 	isSessionOwner,
 	type PidEntry,
 	type SessionOwner,
 	type SessionPidFile,
 	toOwnerKey,
-} from "../../src/pid-schema.js";
+} from "../../runtime/pid-schema.js";
+import {
+	createRuntimePathProvider,
+	type RuntimePathProvider,
+} from "../../runtime/runtime-path-provider.js";
 import { atomicWriteFileSync } from "./atomic-write.js";
 import { acquireFileLock } from "./file-lock.js";
 

--- a/extensions/edit-tool-enhanced/index.ts
+++ b/extensions/edit-tool-enhanced/index.ts
@@ -93,6 +93,7 @@ export default function editLive(pi: ExtensionAPI): void {
 		label: baseEditTool.label,
 		description: baseEditTool.description,
 		parameters: baseEditTool.parameters,
+		prepareArguments: baseEditTool.prepareArguments,
 
 		renderCall(args, theme) {
 			const path = args.path ?? "file";
@@ -109,7 +110,8 @@ export default function editLive(pi: ExtensionAPI): void {
 			const filePath = params.path ?? "file";
 			const effectiveCwd = ctx?.cwd ?? process.cwd();
 			const scopedEditTool = createEditTool(effectiveCwd);
-			const result = await scopedEditTool.execute(toolCallId, params, signal, onUpdate);
+			const prepared = scopedEditTool.prepareArguments?.(params) ?? params;
+			const result = await scopedEditTool.execute(toolCallId, prepared, signal, onUpdate);
 			const details = result.details as EditToolDetails | undefined;
 			const diff = details?.diff ?? "";
 			const absoluteFilename = path.isAbsolute(filePath)

--- a/extensions/prompt-suggestions/__tests__/autocomplete.test.ts
+++ b/extensions/prompt-suggestions/__tests__/autocomplete.test.ts
@@ -44,8 +44,9 @@ function createMockRegistry(
 		find(provider: string, modelId: string) {
 			return models.find((m) => m.provider === provider && m.id === modelId);
 		},
-		async getApiKey(model: Model<Api>) {
-			return keys.get(`${model.provider}/${model.id}`);
+		async getApiKeyForProvider(provider: string) {
+			const entry = [...keys.entries()].find(([k]) => k.startsWith(`${provider}/`));
+			return entry?.[1];
 		},
 		getAvailable() {
 			return models.filter((m) => keys.has(`${m.provider}/${m.id}`));
@@ -191,7 +192,7 @@ describe("resolveAutocompleteModel", () => {
 				findCalls.push(`${provider}/${modelId}`);
 				return undefined;
 			},
-			async getApiKey() {
+			async getApiKeyForProvider() {
 				return undefined;
 			},
 			getAvailable() {

--- a/extensions/prompt-suggestions/autocomplete.ts
+++ b/extensions/prompt-suggestions/autocomplete.ts
@@ -14,8 +14,8 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 export interface ModelRegistryLike {
 	/** Find a model by provider and ID. */
 	find(provider: string, modelId: string): Model<Api> | undefined;
-	/** Get API key for a model. */
-	getApiKey(model: Model<Api>): Promise<string | undefined>;
+	/** Get API key for a provider. */
+	getApiKeyForProvider(provider: string): Promise<string | undefined>;
 	/** Get all models that have auth configured. */
 	getAvailable(): Model<Api>[];
 	/** Register a provider dynamically. */
@@ -102,7 +102,7 @@ export async function tryResolveModel(
 	const model = registry.find(provider, modelId);
 	if (!model) return null;
 
-	const apiKey = await registry.getApiKey(model);
+	const apiKey = await registry.getApiKeyForProvider(model.provider);
 	if (!apiKey) return null;
 
 	return { model, apiKey };
@@ -135,7 +135,7 @@ export async function resolveAutocompleteModel(
 	const available = registry.getAvailable();
 	const sorted = [...available].sort((a, b) => (a.cost?.input ?? 0) - (b.cost?.input ?? 0));
 	for (const model of sorted) {
-		const apiKey = await registry.getApiKey(model);
+		const apiKey = await registry.getApiKeyForProvider(model.provider);
 		if (apiKey) return { model, apiKey };
 	}
 

--- a/extensions/session-memory/index.ts
+++ b/extensions/session-memory/index.ts
@@ -381,7 +381,7 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 
-				const apiKey = await ctx.modelRegistry.getApiKey(model);
+				const apiKey = await ctx.modelRegistry.getApiKeyForProvider(model.provider);
 				if (!apiKey) {
 					ctx.ui.setWorkingMessage();
 					const sc = new Set(results.map((r) => r.sessionId)).size;

--- a/extensions/session-namer/index.ts
+++ b/extensions/session-namer/index.ts
@@ -188,7 +188,7 @@ export default function (pi: ExtensionAPI): void {
 				const model = findNamingModel(ctx);
 				if (!model) return;
 
-				const apiKey = await ctx.modelRegistry.getApiKey(model);
+				const apiKey = await ctx.modelRegistry.getApiKeyForProvider(model.provider);
 				if (!apiKey) return;
 
 				const prompt = buildNamingPrompt(userText, assistantText);

--- a/extensions/teams-tool/sessions/spawn.ts
+++ b/extensions/teams-tool/sessions/spawn.ts
@@ -15,7 +15,7 @@ import {
 	SessionManager,
 	SettingsManager,
 } from "@mariozechner/pi-coding-agent";
-import { applyKnownModelMetadataOverrides } from "../../../src/model-metadata-overrides.js";
+import { applyKnownModelMetadataOverrides } from "../../../runtime/model-metadata-overrides.js";
 import { getTallowHomeDir, getTallowPath } from "../../_shared/tallow-paths.js";
 import {
 	type AgentConfig,
@@ -255,7 +255,7 @@ export async function spawnTeammateSession(
 	// Use the user's tallow auth and model config so teammates inherit
 	// API keys and custom model definitions from the main session.
 	const authStorage = AuthStorage.create(getTallowPath("auth.json"));
-	const modelRegistry = new ModelRegistry(authStorage, getTallowPath("models.json"));
+	const modelRegistry = ModelRegistry.create(authStorage, getTallowPath("models.json"));
 	applyKnownModelMetadataOverrides(modelRegistry);
 	const model = modelRegistry.find(resolvedModel.provider, resolvedModel.id);
 	if (!model) {

--- a/extensions/welcome-screen/index.ts
+++ b/extensions/welcome-screen/index.ts
@@ -11,7 +11,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { TUI } from "@mariozechner/pi-tui";
 import { visibleWidth } from "@mariozechner/pi-tui";
-import { TALLOW_VERSION } from "../../src/config.js";
+import { TALLOW_VERSION } from "../../runtime/config.js";
 
 /** Timeout for npm registry fetch (ms). */
 const FETCH_TIMEOUT = 4_000;

--- a/package.json
+++ b/package.json
@@ -75,24 +75,24 @@
 	"dependencies": {
 		"@clack/prompts": "^1.1.0",
 		"@dungle-scrubs/synapse": "0.1.8",
-		"@mariozechner/pi-coding-agent": "^0.62.0",
+		"@mariozechner/pi-coding-agent": "^0.64.0",
 		"@mariozechner/pi-tui": "workspace:*",
 		"@opentelemetry/api": "^1.9.0",
 		"@sinclair/typebox": "0.34.48",
 		"ai": "^6.0.116",
 		"commander": "^14.0.3",
 		"unpdf": "^1.4.0",
-		"vscode-jsonrpc": "8.2.1"
+		"vscode-jsonrpc": "8.2.1",
+		"vscode-languageserver-protocol": "3.17.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.2",
-		"@mariozechner/pi-agent-core": "^0.62.0",
-		"@mariozechner/pi-ai": "^0.62.0",
+		"@mariozechner/pi-agent-core": "^0.64.0",
+		"@mariozechner/pi-ai": "^0.64.0",
 		"@types/node": "25.2.3",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.4.0",
-		"typescript": "^5.9.3",
-		"vscode-languageserver-protocol": "3.17.5"
+		"typescript": "^5.9.3"
 	},
 	"engines": {
 		"node": ">=22"

--- a/runtime/config.ts
+++ b/runtime/config.ts
@@ -1,0 +1,7 @@
+import { resolveRuntimeModuleUrl } from "./resolve-module.js";
+
+const mod = (await import(
+	resolveRuntimeModuleUrl("config.js")
+)) as typeof import("../src/config.js");
+
+export const TALLOW_VERSION = mod.TALLOW_VERSION;

--- a/runtime/model-metadata-overrides.ts
+++ b/runtime/model-metadata-overrides.ts
@@ -1,0 +1,7 @@
+import { resolveRuntimeModuleUrl } from "./resolve-module.js";
+
+const mod = (await import(
+	resolveRuntimeModuleUrl("model-metadata-overrides.js")
+)) as typeof import("../src/model-metadata-overrides.js");
+
+export const applyKnownModelMetadataOverrides = mod.applyKnownModelMetadataOverrides;

--- a/skills/tallow-expert/SKILL.md
+++ b/skills/tallow-expert/SKILL.md
@@ -59,8 +59,8 @@ Extensions export a default function receiving `ExtensionAPI` (conventionally na
 
 #### Registration
 
-- `registerTool(tool: ToolDefinition<TParams, TDetails>)` — Register a tool that the LLM can call.
-- `registerCommand(name: string, options: Omit<RegisteredCommand, "name">)` — Register a custom command.
+- `registerTool(tool: ToolDefinition<TParams, TDetails, TState>)` — Register a tool that the LLM can call.
+- `registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">)` — Register a custom command.
 - `registerFlag(name: string, options: object)` — Register a CLI flag.
 - `registerMessageRenderer(customType: string, renderer: MessageRenderer<T>)` — Register a custom renderer for CustomMessageEntry.
 - `registerProvider(name: string, config: ProviderConfig)` — Register or override a model provider.
@@ -81,7 +81,7 @@ Extensions export a default function receiving `ExtensionAPI` (conventionally na
 - `getFlag(name: string)` — Get the value of a registered CLI flag.
 - `exec(command: string, args: string[], options?: ExecOptions)` — Execute a shell command.
 - `getActiveTools()` — Get the list of currently active tool names.
-- `getAllTools()` — Get all configured tools with name and description.
+- `getAllTools()` — Get all configured tools with parameter schema and source metadata.
 - `setActiveTools(toolNames: string[])` — Set the active tools by name.
 - `getCommands()` — Get available slash commands in the current session.
 - `setModel(model: Model<any>)` — Set the current model.
@@ -154,6 +154,7 @@ Extensions export a default function receiving `ExtensionAPI` (conventionally na
 - `modelRegistry` — Model registry for API key resolution
 - `model` — Current model (may be undefined)
 - `isIdle()` — Whether the agent is idle (not streaming)
+- `signal` — The current abort signal, or undefined when the agent is not streaming.
 - `abort()` — Abort the current agent operation
 - `hasPendingMessages()` — Whether there are queued messages waiting
 - `shutdown()` — Gracefully shutdown pi and exit.
@@ -178,6 +179,7 @@ Extensions export a default function receiving `ExtensionAPI` (conventionally na
 - `onTerminalInput(handler: TerminalInputHandler)` — Listen to raw terminal input (interactive mode only).
 - `setStatus(key: string, text: string)` — Set status text in the footer/status bar.
 - `setWorkingMessage(message?: string)` — Set the working/loading message shown during streaming.
+- `setHiddenThinkingLabel(label?: string)` — Set the label shown for hidden thinking blocks.
 - `setWidget(key: string, content: string[], options?: ExtensionWidgetOptions)` — Set a widget to display above or below the editor.
 - `setTitle(title: string)` — Set the terminal window/tab title.
 - `pasteToEditor(text: string)` — Paste text into the editor, triggering paste handling (collapse for large content).

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1553,7 +1553,7 @@ export async function createTallowSession(
 			`\x1b[33m🔐 Migrated ${migration.migratedProviders.length} auth credential(s) to secure references: ${migration.migratedProviders.join(", ")}\x1b[0m`
 		);
 	}
-	const modelRegistry = new ModelRegistry(authStorage, join(tallowHome, "models.json"));
+	const modelRegistry = ModelRegistry.create(authStorage, join(tallowHome, "models.json"));
 	applyKnownModelMetadataOverrides(modelRegistry);
 
 	// ── Runtime API key (not persisted) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix 3 bundled extensions (`background-task-tool`, `lsp`, `teams-tool`) failing to load on fresh npm installs
- Bump `pi-*` dependencies from 0.62.0 → 0.64.0
- Adapt to upstream API changes

## Changes Made

### Packaging fixes (closes #231, closes #232)
- **`extensions/_shared/pid-registry.ts`** — import from `runtime/pid-schema.js` instead of unpublished `src/pid-schema.js`
- **`extensions/teams-tool/sessions/spawn.ts`** — import from `runtime/model-metadata-overrides.js` instead of `src/`
- **`extensions/welcome-screen/index.ts`** — import from `runtime/config.js` instead of `src/`
- **`runtime/config.ts`** and **`runtime/model-metadata-overrides.ts`** — new runtime wrappers following established pattern
- **`package.json`** — move `vscode-languageserver-protocol` from `devDependencies` to `dependencies`

### Dependency bump (closes #223)
- `@mariozechner/pi-coding-agent`: ^0.62.0 → ^0.64.0
- `@mariozechner/pi-agent-core`: ^0.62.0 → ^0.64.0
- `@mariozechner/pi-ai`: ^0.62.0 → ^0.64.0

### API adaptations for pi 0.64.0
- **`src/sdk.ts`** — `new ModelRegistry()` → `ModelRegistry.create()` (constructor now private)
- **`extensions/teams-tool/sessions/spawn.ts`** — same ModelRegistry change
- **`extensions/session-memory`**, **`session-namer`**, **`prompt-suggestions`** — `getApiKey(model)` → `getApiKeyForProvider(model.provider)`
- **`extensions/edit-tool-enhanced`** — propagate upstream `prepareArguments` normalization so old `{oldText, newText}` format still works

## Testing

- `bun run build` ✅
- `bun run typecheck` ✅
- `bun run typecheck:extensions` ✅
- `bun run lint` ✅ (no errors)
- `bun test` — 2778 pass, 3 fail (all 3 pre-existing on main)
- `bun run test:docs` ✅