### PR TITLE
fix: disable reasoning metadata for MiniMax models to fix compact failures

### DIFF
--- a/skills/tallow-expert/SKILL.md
+++ b/skills/tallow-expert/SKILL.md
@@ -59,8 +59,8 @@ Extensions export a default function receiving `ExtensionAPI` (conventionally na
 
 #### Registration
 
-- `registerTool(tool: ToolDefinition<TParams, TDetails>)` — Register a tool that the LLM can call.
-- `registerCommand(name: string, options: Omit<RegisteredCommand, "name">)` — Register a custom command.
+- `registerTool(tool: ToolDefinition<TParams, TDetails, TState>)` — Register a tool that the LLM can call.
+- `registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">)` — Register a custom command.
 - `registerFlag(name: string, options: object)` — Register a CLI flag.
 - `registerMessageRenderer(customType: string, renderer: MessageRenderer<T>)` — Register a custom renderer for CustomMessageEntry.
 - `registerProvider(name: string, config: ProviderConfig)` — Register or override a model provider.
@@ -81,7 +81,7 @@ Extensions export a default function receiving `ExtensionAPI` (conventionally na
 - `getFlag(name: string)` — Get the value of a registered CLI flag.
 - `exec(command: string, args: string[], options?: ExecOptions)` — Execute a shell command.
 - `getActiveTools()` — Get the list of currently active tool names.
-- `getAllTools()` — Get all configured tools with name and description.
+- `getAllTools()` — Get all configured tools with parameter schema and source metadata.
 - `setActiveTools(toolNames: string[])` — Set the active tools by name.
 - `getCommands()` — Get available slash commands in the current session.
 - `setModel(model: Model<any>)` — Set the current model.

--- a/src/model-metadata-overrides.ts
+++ b/src/model-metadata-overrides.ts
@@ -30,6 +30,29 @@ const KNOWN_CONTEXT_WINDOW_OVERRIDES: Record<string, Record<string, ContextWindo
 	},
 };
 
+/**
+ * MiniMax models don't properly support the reasoning parameter in
+ * completion/summarization calls through OpenRouter. When reasoningEffort
+ * is not explicitly provided, pi-ai's OpenRouter handler sends
+ * `reasoning: { effort: "none" }`, which MiniMax rejects with:
+ * "Reasoning is mandatory for this endpoint and cannot be disabled."
+ *
+ * Setting `reasoning: false` prevents the OpenRouter handler from sending
+ * the reasoning parameter at all, avoiding this error during compaction.
+ */
+const KNOWN_REASONING_OVERRIDES: Record<string, Record<string, boolean>> = {
+	openrouter: {
+		// MiniMax models via OpenRouter — reasoning breaks compact/summarization
+		"minimax/minimax-m2.7": false,
+		"minimax/minimax-m2.7-highspeed": false,
+	},
+	"amazon-bedrock": {
+		// MiniMax models via Bedrock — same reasoning parameter issue
+		"minimax.minimax-m2": false,
+		"minimax.minimax-m2.1": false,
+	},
+};
+
 interface ModelRegistryLike {
 	getAll(): Model<Api>[];
 }
@@ -47,15 +70,25 @@ export function applyKnownModelMetadataOverrides(modelRegistry: ModelRegistryLik
 	let applied = 0;
 
 	for (const model of modelRegistry.getAll()) {
+		// Context window corrections
 		const providerOverrides = KNOWN_CONTEXT_WINDOW_OVERRIDES[model.provider];
-		if (!providerOverrides) continue;
+		if (providerOverrides) {
+			const correction = providerOverrides[model.id];
+			if (correction && model.contextWindow === correction.stale) {
+				model.contextWindow = correction.correct;
+				applied += 1;
+			}
+		}
 
-		const correction = providerOverrides[model.id];
-		if (!correction) continue;
-		if (model.contextWindow !== correction.stale) continue;
-
-		model.contextWindow = correction.correct;
-		applied += 1;
+		// Reasoning corrections for MiniMax
+		const reasoningOverrides = KNOWN_REASONING_OVERRIDES[model.provider];
+		if (reasoningOverrides) {
+			const override = reasoningOverrides[model.id];
+			if (override !== undefined && model.reasoning !== override) {
+				model.reasoning = override;
+				applied += 1;
+			}
+		}
 	}
 
 	return applied;


### PR DESCRIPTION
## Summary

Fixes context overflow recovery failures for MiniMax models by disabling the  metadata flag.

### Root Cause

MiniMax models have  in pi-ai's registry. During compaction (overflow recovery), pi-coding-agent passes  to the API. pi-ai's OpenRouter handler then sends  when reasoning isn't explicitly provided, which MiniMax rejects with:

> "Reasoning is mandatory for this endpoint and cannot be disabled"

### Fix

Override  for MiniMax models in :

- `openrouter: { minimax/minimax-m2.7: false, minimax/minimax-m2.7-highspeed: false }`
- `amazon-bedrock: { minimax.minimax-m2: false, minimax.minimax-m2.1: false }`

### Testing

- [x] Typecheck passes
- [x] Unit tests pass