### PR TITLE
fix: stabilize redraws, tasks layout, and runtime packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **interactive:** stabilize settings submenu transitions so changing thinking
+  level no longer triggers chat re-append jitter or viewport jumps
+- **interactive:** reset render grace before chat rebuild paths
+  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
+  churn across reload, fork, navigation, and settings-driven rebuilds
+- **runtime:** remove published runtime wrapper references to `src/`, making
+  global installs resilient when only `runtime/` and `dist/` are shipped
+- **tasks:** top-align the side-by-side background column and require a wider
+  terminal before using split layout, removing large blank gaps above
+  background task content
+
 ## [0.9.3](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.2...tallow-v0.9.3) (2026-04-02)
 
 
 ### Fixed
 
 * **auto-rebuild:** install stale dependencies before rebuilding ([d07da7a](https://github.com/dungle-scrubs/tallow/commit/d07da7a88b4133e635f22e5d42e59adf7d2db8d4))
-
-## [Unreleased]
-
-### Fixed
-
-- **auto-rebuild:** run `bun install` when dependencies are stale before
-  rebuilding, preventing build failures after `git pull` bumps upstream packages
-- **auto-rebuild:** include `bun.lock` in staleness inputs so lockfile-only
-  changes trigger a rebuild
-- **tests:** isolate `assessCliAutoRebuild` tests from inherited env vars
 
 ## [0.9.2](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.1...tallow-v0.9.2) (2026-04-02)
 

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -12,11 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **auto-rebuild:** run `bun install` when dependencies are stale before
-  rebuilding, preventing build failures after `git pull` bumps upstream packages
-- **auto-rebuild:** include `bun.lock` in staleness inputs so lockfile-only
-  changes trigger a rebuild
-- **tests:** isolate `assessCliAutoRebuild` tests from inherited env vars
+- **interactive:** stabilize settings submenu transitions so changing thinking
+  level no longer triggers chat re-append jitter or viewport jumps
+- **interactive:** reset render grace before chat rebuild paths
+  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
+  churn across reload, fork, navigation, and settings-driven rebuilds
+- **runtime:** remove published runtime wrapper references to `src/`, making
+  global installs resilient when only `runtime/` and `dist/` are shipped
+- **tasks:** top-align the side-by-side background column and require a wider
+  terminal before using split layout, removing large blank gaps above
+  background task content
+
+## [0.9.3](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.2...tallow-v0.9.3) (2026-04-02)
+
+
+### Fixed
+
+* **auto-rebuild:** install stale dependencies before rebuilding ([d07da7a](https://github.com/dungle-scrubs/tallow/commit/d07da7a88b4133e635f22e5d42e59adf7d2db8d4))
 
 ## [0.9.2](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.1...tallow-v0.9.2) (2026-04-02)
 

--- a/extensions/__integration__/audit-findings.test.ts
+++ b/extensions/__integration__/audit-findings.test.ts
@@ -9,20 +9,11 @@
  * - session_shutdown handlers fire during cleanup
  */
 
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { ExtensionHarness } from "../../test-utils/extension-harness.js";
-import { createScriptedStreamFn } from "../../test-utils/mock-model.js";
-import { createSessionRunner, type SessionRunner } from "../../test-utils/session-runner.js";
-
-let runner: SessionRunner | undefined;
-
-afterEach(() => {
-	runner?.dispose();
-	runner = undefined;
-});
 
 // ════════════════════════════════════════════════════════════════
 // Audit Finding 1.1: Dead cwd_changed listener removed
@@ -61,7 +52,7 @@ describe("session_shutdown type safety", () => {
 			if (!existsSync(indexPath)) continue;
 			const source = readFileSync(indexPath, "utf-8");
 			if (source.includes('session_shutdown" as never')) {
-				violations.push(dir.split("/").pop()!);
+				violations.push(dir.split("/").at(-1) ?? dir);
 			}
 		}
 

--- a/extensions/__integration__/teams-runtime.test.ts
+++ b/extensions/__integration__/teams-runtime.test.ts
@@ -226,7 +226,10 @@ describe("Teams runtime wiring", () => {
 		task.assignee = "alice";
 		const archived = archiveTeam(team.name);
 		expect(archived).toBeDefined();
-		writeArchivedTeamToDisk(archived!);
+		if (!archived) {
+			throw new Error("expected archiveTeam() to return archived team data");
+		}
+		writeArchivedTeamToDisk(archived);
 
 		const resume = getTool(harness, "team_resume");
 

--- a/extensions/_shared/pid-registry.ts
+++ b/extensions/_shared/pid-registry.ts
@@ -15,7 +15,6 @@ import { dirname, join } from "node:path";
 import {
 	isPidEntry,
 	isSessionOwner,
-	type PidEntry,
 	type SessionOwner,
 	type SessionPidFile,
 	toOwnerKey,

--- a/extensions/clear/__tests__/clear.test.ts
+++ b/extensions/clear/__tests__/clear.test.ts
@@ -32,7 +32,7 @@ describe("clear extension", () => {
 		registerClear(pi);
 
 		const newSession = mock(() => Promise.resolve());
-		await handler!("", { newSession });
+		await handler?.("", { newSession });
 		expect(newSession).toHaveBeenCalledTimes(1);
 	});
 });

--- a/extensions/permissions/__tests__/permissions.test.ts
+++ b/extensions/permissions/__tests__/permissions.test.ts
@@ -5,7 +5,7 @@
  * other test files in the same Bun worker. Tests cover command/handler
  * registration and event handler presence without mocking the _shared modules.
  */
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { ExtensionHarness } from "../../../test-utils/extension-harness.js";
 import registerPermissions from "../index.js";
@@ -71,7 +71,7 @@ describe("permissions extension registration", () => {
 describe("tool_call handler", () => {
 	test("skips bash tool (handled by shell-policy)", async () => {
 		const { handlers } = captureRegistrations();
-		const result = await handlers.tool_call!(
+		const result = await handlers.tool_call?.(
 			{ type: "tool_call", toolName: "bash", toolCallId: "t1", input: { command: "ls" } },
 			{ cwd: "/tmp", hasUI: false, ui: {} } as unknown as ExtensionContext
 		);
@@ -81,7 +81,7 @@ describe("tool_call handler", () => {
 
 	test("skips bg_bash tool (handled by shell-policy)", async () => {
 		const { handlers } = captureRegistrations();
-		const result = await handlers.tool_call!(
+		const result = await handlers.tool_call?.(
 			{ type: "tool_call", toolName: "bg_bash", toolCallId: "t2", input: { command: "ls" } },
 			{ cwd: "/tmp", hasUI: false, ui: {} } as unknown as ExtensionContext
 		);
@@ -92,7 +92,7 @@ describe("tool_call handler", () => {
 		const { handlers } = captureRegistrations();
 		// Session-start hasn't been called yet, so currentCwd is "", and
 		// getPermissions("") returns empty rules → skip
-		const result = await handlers.tool_call!(
+		const result = await handlers.tool_call?.(
 			{
 				type: "tool_call",
 				toolName: "read",

--- a/extensions/render-stabilizer/__tests__/render-stabilizer.test.ts
+++ b/extensions/render-stabilizer/__tests__/render-stabilizer.test.ts
@@ -8,16 +8,16 @@ describe("render-stabilizer extension", () => {
 		const mockPi = {
 			on(event: string, handler: unknown) {
 				if (!handlers.has(event)) handlers.set(event, []);
-				handlers.get(event)!.push(handler);
+				handlers.get(event)?.push(handler);
 			},
 		};
 
 		renderStabilizerExtension(mockPi as never);
 
 		expect(handlers.has("session_start")).toBe(true);
-		expect(handlers.get("session_start")!.length).toBe(1);
+		expect(handlers.get("session_start")?.length).toBe(1);
 		expect(handlers.has("session_before_switch")).toBe(true);
-		expect(handlers.get("session_before_switch")!.length).toBe(1);
+		expect(handlers.get("session_before_switch")?.length).toBe(1);
 	});
 
 	it("does not register any commands or tools", () => {

--- a/extensions/show-system-prompt/__tests__/show-system-prompt.test.ts
+++ b/extensions/show-system-prompt/__tests__/show-system-prompt.test.ts
@@ -40,7 +40,7 @@ describe("show-system-prompt extension", () => {
 			logged.push(args.join(" "));
 		};
 		try {
-			await handler!("", ctx);
+			await handler?.("", ctx);
 		} finally {
 			console.log = origLog;
 		}

--- a/extensions/subagent-tool/index.ts
+++ b/extensions/subagent-tool/index.ts
@@ -1412,7 +1412,7 @@ function renderSubagentCall(args: Record<string, unknown>, theme: Theme) {
 		return new Text(lines.join("\n"), 0, 0);
 	}
 
-	const agentName = (args.agent as string) || "...";
+	const _agentName = (args.agent as string) || "...";
 	const task = typeof args.task === "string" ? args.task : "...";
 	// Single mode: skip the redundant "subagent single" header — the result
 	// renderer already shows "subagent running <duration> <agent>" with a spinner.

--- a/extensions/tasks/__tests__/state-ui.test.ts
+++ b/extensions/tasks/__tests__/state-ui.test.ts
@@ -114,10 +114,10 @@ describe("tasks ui helpers", () => {
 		expect(visibleWidth(truncated)).toBe(3);
 	});
 
-	it("mergeSideBySide bottom-aligns right column and keeps width bounds", () => {
+	it("mergeSideBySide top-aligns right column and keeps width bounds", () => {
 		const merged = mergeSideBySide(["left1", "left2", "left3"], ["right"], 6, " | ", 16);
 		expect(merged).toHaveLength(3);
-		expect(merged[0]).toBe("left1  | ");
-		expect(merged[2]).toContain("right");
+		expect(merged[0]).toContain("right");
+		expect(merged[2]).toBe("left3  | ");
 	});
 });

--- a/extensions/tasks/__tests__/widget-subagents.test.ts
+++ b/extensions/tasks/__tests__/widget-subagents.test.ts
@@ -406,7 +406,7 @@ describe("tasks widget subagent sections", () => {
 			expectLinesWithinWidth(stackedNarrow, 55);
 			expectLinesWithinWidth(stackedWide, 95);
 
-			const sideBySideNarrow = renderWidget(fixture.captured, 124);
+			const sideBySideNarrow = renderWidget(fixture.captured, 144);
 			const sideBySideWide = renderWidget(fixture.captured, 180);
 			const sideBySideNarrowPreview = extractPreview(sideBySideNarrow, "seg01");
 			const sideBySideWidePreview = extractPreview(sideBySideWide, "seg01");
@@ -417,7 +417,7 @@ describe("tasks widget subagent sections", () => {
 			expect(visibleWidth(sideBySideWidePreview)).toBeGreaterThan(
 				visibleWidth(sideBySideNarrowPreview)
 			);
-			expectLinesWithinWidth(sideBySideNarrow, 124);
+			expectLinesWithinWidth(sideBySideNarrow, 144);
 			expectLinesWithinWidth(sideBySideWide, 180);
 		} finally {
 			await shutdownFixture(fixture);

--- a/extensions/tasks/commands/register-tasks-extension.ts
+++ b/extensions/tasks/commands/register-tasks-extension.ts
@@ -685,7 +685,7 @@ export function registerTasksExtension(
 				const useSideBySide = width >= MIN_SIDE_BY_SIDE_WIDTH && hasTasks && hasRightColumn;
 
 				if (useSideBySide) {
-					// Side-by-side: tasks on left, subagents + bg tasks on right (bottom-aligned)
+					// Side-by-side: tasks on left, subagents + bg tasks on right
 					const separator = "\x1b[38;2;60;60;70m  │  \x1b[0m"; // Dark gray
 					const separatorWidth = 5; // "  │  " is 5 visible chars
 					const leftColumnWidth = Math.floor((width - separatorWidth) / 2);

--- a/extensions/tasks/state/index.ts
+++ b/extensions/tasks/state/index.ts
@@ -38,7 +38,7 @@ export const LEGACY_TEAMS_DIR = getTallowPath("teams");
 export const TEAM_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Minimum width for side-by-side layout (tasks left, subagents right). */
-export const MIN_SIDE_BY_SIDE_WIDTH = 120;
+export const MIN_SIDE_BY_SIDE_WIDTH = 140;
 
 /** Prefix used for session-scoped shared task-group directories. */
 const SESSION_TASK_GROUP_PREFIX = "task-group";

--- a/extensions/tasks/ui/index.ts
+++ b/extensions/tasks/ui/index.ts
@@ -45,7 +45,7 @@ export function padToWidth(line: string, targetWidth: number): string {
 }
 
 /**
- * Merge two column arrays into side-by-side lines, with right column bottom-aligned.
+ * Merge two column arrays into side-by-side lines with top-aligned rows.
  *
  * Both columns are truncated to their allotted widths to prevent overflow.
  *
@@ -68,14 +68,9 @@ export function mergeSideBySide(
 	const maxRows = Math.max(leftLines.length, rightLines.length);
 	const result: string[] = [];
 
-	// Bottom-align: pad right column at the top
-	const rightPadding = maxRows - rightLines.length;
-
 	for (let i = 0; i < maxRows; i++) {
 		const left = leftLines[i] ?? "";
-		const rightIndex = i - rightPadding;
-		const rawRight = rightIndex >= 0 ? (rightLines[rightIndex] ?? "") : "";
-		// Truncate right column to prevent overflow
+		const rawRight = rightLines[i] ?? "";
 		const right =
 			rightWidth > 0 && visibleWidth(rawRight) > rightWidth
 				? truncateToWidth(rawRight, rightWidth, "")

--- a/extensions/write-tool-enhanced/__tests__/write-tool-enhanced.test.ts
+++ b/extensions/write-tool-enhanced/__tests__/write-tool-enhanced.test.ts
@@ -68,6 +68,21 @@ function stubContext(): ExtensionContext {
 	} as unknown as ExtensionContext;
 }
 
+/**
+ * Resolve the registered write tool from a loaded harness.
+ *
+ * @param harness - Extension harness with write-tool-enhanced loaded
+ * @returns Registered write tool definition
+ * @throws {Error} When the write tool is unavailable
+ */
+function getWriteTool(harness: ExtensionHarness) {
+	const tool = harness.tools.get("write");
+	if (!tool) {
+		throw new Error("write tool not registered");
+	}
+	return tool;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("write-tool-enhanced", () => {
@@ -109,7 +124,7 @@ describe("write-tool-enhanced", () => {
 			const harness = ExtensionHarness.create();
 			await harness.loadExtension(writePreview);
 
-			const tool = harness.tools.get("write")!;
+			const tool = getWriteTool(harness);
 			const content = "const x = 1;\nconst y = 2;";
 
 			const result = await tool.execute(
@@ -128,7 +143,7 @@ describe("write-tool-enhanced", () => {
 			const harness = ExtensionHarness.create();
 			await harness.loadExtension(writePreview);
 
-			const tool = harness.tools.get("write")!;
+			const tool = getWriteTool(harness);
 			const content = "line1\nline2\nline3"; // 3 lines
 
 			const result = await tool.execute(
@@ -148,7 +163,7 @@ describe("write-tool-enhanced", () => {
 			const harness = ExtensionHarness.create();
 			await harness.loadExtension(writePreview);
 
-			const tool = harness.tools.get("write")!;
+			const tool = getWriteTool(harness);
 			// 1200 chars → 1200/1024 ≈ 1.171875 → toFixed(1) = "1.2"
 			const content = "a".repeat(1200);
 			const expectedKb = (content.length / 1024).toFixed(1);
@@ -170,7 +185,7 @@ describe("write-tool-enhanced", () => {
 			const harness = ExtensionHarness.create();
 			await harness.loadExtension(writePreview);
 
-			const tool = harness.tools.get("write")!;
+			const tool = getWriteTool(harness);
 			const content = "hello\nworld"; // 2 lines, 11 chars
 
 			const result = await tool.execute(
@@ -190,7 +205,7 @@ describe("write-tool-enhanced", () => {
 			const harness = ExtensionHarness.create();
 			await harness.loadExtension(writePreview);
 
-			const tool = harness.tools.get("write")!;
+			const tool = getWriteTool(harness);
 
 			const result = await tool.execute(
 				"test-id",
@@ -211,7 +226,7 @@ describe("write-tool-enhanced", () => {
 			const harness = ExtensionHarness.create();
 			await harness.loadExtension(writePreview);
 
-			const tool = harness.tools.get("write")!;
+			const tool = getWriteTool(harness);
 
 			await expect(
 				tool.execute(

--- a/packages/tallow-tui/src/__tests__/settings-list.test.ts
+++ b/packages/tallow-tui/src/__tests__/settings-list.test.ts
@@ -46,4 +46,36 @@ describe("SettingsList submenu transitions", () => {
 		expect(firstFrameAfterClose.length).toBe(submenuLines.length);
 		expect(secondFrameAfterClose.length).toBe(initialLines.length);
 	});
+
+	it("fires the layout transition callback when opening and closing a submenu", () => {
+		const list = new SettingsList(
+			[
+				{
+					id: "thinking",
+					label: "Thinking level",
+					currentValue: "medium",
+					submenu: (_currentValue, done) => ({
+						handleInput: () => done("high"),
+						invalidate: () => {},
+						render: () => ["submenu", "one", "two"],
+					}),
+				},
+			],
+			10,
+			theme,
+			() => {},
+			() => {}
+		);
+		const transitions: string[] = [];
+		list.setLayoutTransitionCallback(() => {
+			transitions.push("transition");
+		});
+
+		list.render(80);
+		list.handleInput(" ");
+		list.render(80);
+		list.handleInput("x");
+
+		expect(transitions).toEqual(["transition", "transition"]);
+	});
 });

--- a/packages/tallow-tui/src/components/settings-list.ts
+++ b/packages/tallow-tui/src/components/settings-list.ts
@@ -47,6 +47,7 @@ export class SettingsList implements Component {
 	private submenuItemIndex: number | null = null;
 	private lastRenderLineCount = 0;
 	private nextMinLineCount = 0;
+	private layoutTransitionCallback?: () => void;
 
 	constructor(
 		items: SettingItem[],
@@ -68,12 +69,31 @@ export class SettingsList implements Component {
 		}
 	}
 
-	/** Update an item's currentValue */
+	/**
+	 * Update an item's current value.
+	 *
+	 * @param id - Setting identifier
+	 * @param newValue - New value to display
+	 * @returns Nothing
+	 */
 	updateValue(id: string, newValue: string): void {
 		const item = this.items.find((i) => i.id === id);
 		if (item) {
 			item.currentValue = newValue;
 		}
+	}
+
+	/**
+	 * Set a callback fired before submenu-driven layout transitions.
+	 *
+	 * Callers can use this to reset TUI render-grace state before the settings
+	 * list expands into, or collapses out of, a submenu.
+	 *
+	 * @param callback - Transition callback, or undefined to clear it
+	 * @returns Nothing
+	 */
+	setLayoutTransitionCallback(callback?: () => void): void {
+		this.layoutTransitionCallback = callback;
 	}
 
 	invalidate(): void {
@@ -225,6 +245,7 @@ export class SettingsList implements Component {
 			// Preserve height for the first submenu frame so the TUI doesn't treat
 			// the editor→submenu swap as a destructive shrink/expand transition.
 			this.nextMinLineCount = this.lastRenderLineCount;
+			this.layoutTransitionCallback?.();
 			this.submenuItemIndex = this.selectedIndex;
 			this.submenuComponent = item.submenu(item.currentValue, (selectedValue?: string) => {
 				if (selectedValue !== undefined) {
@@ -243,10 +264,16 @@ export class SettingsList implements Component {
 		}
 	}
 
+	/**
+	 * Close the active submenu and restore the main settings list.
+	 *
+	 * @returns Nothing
+	 */
 	private closeSubmenu(): void {
 		// Preserve one frame of the submenu height so the transition back to the
 		// main settings list doesn't trigger a screen-clearing shrink redraw.
 		this.nextMinLineCount = this.lastRenderLineCount;
+		this.layoutTransitionCallback?.();
 		this.submenuComponent = null;
 		// Restore selection to the item that opened the submenu
 		if (this.submenuItemIndex !== null) {

--- a/packages/tallow-tui/src/keybindings.ts
+++ b/packages/tallow-tui/src/keybindings.ts
@@ -310,7 +310,7 @@ function normalizeKeyArray(value: KeyId | readonly KeyId[]): readonly KeyId[] {
  * @param {KeybindingsConfig} userBindings - Raw user bindings.
  * @returns {NormalizedKeybindingsConfig} Normalized modern binding map.
  */
-function normalizeUserBindings(userBindings: KeybindingsConfig): NormalizedKeybindingsConfig {
+function _normalizeUserBindings(userBindings: KeybindingsConfig): NormalizedKeybindingsConfig {
 	const normalized: NormalizedKeybindingsConfig = {};
 
 	for (const [rawKey, rawValue] of Object.entries(userBindings)) {

--- a/runtime/model-metadata-overrides.ts
+++ b/runtime/model-metadata-overrides.ts
@@ -1,7 +1,16 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
 import { resolveRuntimeModuleUrl } from "./resolve-module.js";
+
+interface ModelRegistryLike {
+	getAll(): Model<Api>[];
+}
+
+interface ModelMetadataOverridesModule {
+	applyKnownModelMetadataOverrides(modelRegistry: ModelRegistryLike): number;
+}
 
 const mod = (await import(
 	resolveRuntimeModuleUrl("model-metadata-overrides.js")
-)) as typeof import("../src/model-metadata-overrides.js");
+)) as ModelMetadataOverridesModule;
 
 export const applyKnownModelMetadataOverrides = mod.applyKnownModelMetadataOverrides;

--- a/runtime/pid-schema.ts
+++ b/runtime/pid-schema.ts
@@ -1,12 +1,32 @@
 import { resolveRuntimeModuleUrl } from "./resolve-module.js";
 
-const pidSchemaModule = (await import(
-	resolveRuntimeModuleUrl("pid-schema.js")
-)) as typeof import("../src/pid-schema.js");
+export interface PidEntry {
+	command: string;
+	ownerPid?: number;
+	ownerStartedAt?: string;
+	pid: number;
+	processStartedAt?: string;
+	startedAt: number;
+}
 
-export type PidEntry = import("../src/pid-schema.js").PidEntry;
-export type SessionOwner = import("../src/pid-schema.js").SessionOwner;
-export type SessionPidFile = import("../src/pid-schema.js").SessionPidFile;
+export interface SessionOwner {
+	pid: number;
+	startedAt?: string;
+}
+
+export interface SessionPidFile {
+	entries: PidEntry[];
+	owner: SessionOwner;
+	version: 2;
+}
+
+interface PidSchemaModule {
+	isPidEntry(value: unknown): value is PidEntry;
+	isSessionOwner(value: unknown): value is SessionOwner;
+	toOwnerKey(owner: SessionOwner): string;
+}
+
+const pidSchemaModule = (await import(resolveRuntimeModuleUrl("pid-schema.js"))) as PidSchemaModule;
 
 export const isPidEntry = pidSchemaModule.isPidEntry;
 export const isSessionOwner = pidSchemaModule.isSessionOwner;

--- a/scripts/patch-upstream-debug.mjs
+++ b/scripts/patch-upstream-debug.mjs
@@ -77,7 +77,10 @@ function patchMiniMax(target) {
 	if (content.includes("MINIMAX_ALREADY_PATCHED")) return false;
 	if (!content.includes(MINIMAX_BUGGY)) return false;
 
-	const patched = content.replace(MINIMAX_BUGGY, `${MINIMAX_FIXED}\n    // MINIMAX_ALREADY_PATCHED`);
+	const patched = content.replace(
+		MINIMAX_BUGGY,
+		`${MINIMAX_FIXED}\n    // MINIMAX_ALREADY_PATCHED`
+	);
 	writeFileSync(target, patched);
 	return true;
 }

--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -176,6 +176,24 @@ class FakeInteractiveMode {
 	}
 
 	/**
+	 * Base renderInitialMessages implementation used by the patch wrapper.
+	 *
+	 * @returns Nothing
+	 */
+	renderInitialMessages(): void {
+		this.lifecycleCalls.push("renderInitialMessages");
+	}
+
+	/**
+	 * Base rebuildChatFromMessages implementation used by the patch wrapper.
+	 *
+	 * @returns Nothing
+	 */
+	rebuildChatFromMessages(): void {
+		this.lifecycleCalls.push("rebuildChatFromMessages");
+	}
+
+	/**
 	 * Base executeCompaction implementation used by the patch wrapper.
 	 *
 	 * @param _customInstructions - Optional compaction instructions
@@ -583,8 +601,54 @@ describe("patchInteractiveModePrototype", () => {
 		done?.();
 
 		expect(mode.renderGraceResets).toBe(2);
-		expect(mode.renderRequests).toBe(1);
+		expect(mode.renderRequests).toBe(2);
 		expect(mode.lifecycleCalls).toContain("ui.resetRenderGrace");
+	});
+
+	it("binds settings submenu layout transitions to stable renders", () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+		let layoutTransition: (() => void) | undefined;
+
+		mode.showSelector(() => ({
+			component: {
+				getSettingsList: () => ({
+					setLayoutTransitionCallback: (callback?: () => void) => {
+						layoutTransition = callback;
+					},
+				}),
+			},
+			focus: "selector",
+		}));
+
+		expect(typeof layoutTransition).toBe("function");
+		const resetsBefore = mode.renderGraceResets;
+		const rendersBefore = mode.renderRequests;
+		layoutTransition?.();
+		expect(mode.renderGraceResets).toBe(resetsBefore + 1);
+		expect(mode.renderRequests).toBe(rendersBefore + 1);
+	});
+
+	it("resets render grace before renderInitialMessages", () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		mode.renderInitialMessages();
+
+		expect(mode.renderGraceResets).toBe(1);
+		expect(mode.renderRequests).toBe(1);
+		expect(mode.lifecycleCalls).toContain("renderInitialMessages");
+	});
+
+	it("resets render grace before rebuildChatFromMessages", () => {
+		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
+		const mode = new FakeInteractiveMode();
+
+		mode.rebuildChatFromMessages();
+
+		expect(mode.renderGraceResets).toBe(1);
+		expect(mode.renderRequests).toBe(1);
+		expect(mode.lifecycleCalls).toContain("rebuildChatFromMessages");
 	});
 
 	it("allows idle setWorkingMessage for post-compaction resuming indicators", () => {

--- a/src/__tests__/runtime-wrappers.test.ts
+++ b/src/__tests__/runtime-wrappers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Copy the minimal runtime-wrapper fixture into an isolated temp directory.
+ *
+ * The fixture intentionally omits `src/` so wrapper imports must resolve via
+ * the published-package layout (`runtime/` + `dist/`) instead of source files.
+ *
+ * @returns Absolute path to the temporary fixture root
+ */
+function createRuntimeWrapperFixture(): string {
+	const fixtureDir = mkdtempSync(join(tmpdir(), "tallow-runtime-wrapper-"));
+	mkdirSync(join(fixtureDir, "dist"), { recursive: true });
+	mkdirSync(join(fixtureDir, "runtime"), { recursive: true });
+	writeFileSync(join(fixtureDir, "package.json"), JSON.stringify({ type: "module" }));
+
+	copyFileSync("runtime/resolve-module.ts", join(fixtureDir, "runtime", "resolve-module.ts"));
+	copyFileSync("runtime/pid-schema.ts", join(fixtureDir, "runtime", "pid-schema.ts"));
+	copyFileSync(
+		"runtime/model-metadata-overrides.ts",
+		join(fixtureDir, "runtime", "model-metadata-overrides.ts")
+	);
+	copyFileSync("dist/pid-schema.js", join(fixtureDir, "dist", "pid-schema.js"));
+	copyFileSync(
+		"dist/model-metadata-overrides.js",
+		join(fixtureDir, "dist", "model-metadata-overrides.js")
+	);
+
+	return fixtureDir;
+}
+
+describe("runtime wrappers", () => {
+	it("loads pid-schema wrapper without a src directory", async () => {
+		const fixtureDir = createRuntimeWrapperFixture();
+		const moduleUrl = pathToFileURL(join(fixtureDir, "runtime", "pid-schema.ts")).href;
+		const mod = await import(moduleUrl);
+
+		expect(typeof mod.isPidEntry).toBe("function");
+		expect(typeof mod.isSessionOwner).toBe("function");
+		expect(typeof mod.toOwnerKey).toBe("function");
+		expect(mod.isPidEntry({ command: "bun", pid: 1, startedAt: Date.now() })).toBe(true);
+	});
+
+	it("loads model-metadata-overrides wrapper without a src directory", async () => {
+		const fixtureDir = createRuntimeWrapperFixture();
+		const moduleUrl = pathToFileURL(
+			join(fixtureDir, "runtime", "model-metadata-overrides.ts")
+		).href;
+		const mod = await import(moduleUrl);
+
+		expect(typeof mod.applyKnownModelMetadataOverrides).toBe("function");
+		expect(mod.applyKnownModelMetadataOverrides({ getAll: () => [] })).toBe(0);
+	});
+});

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -28,6 +28,7 @@ interface SessionLike {
 }
 
 interface InteractiveModeInstanceLike {
+	chatContainer?: { clear?: (() => void) | undefined };
 	compactionQueuedMessages?: Array<unknown>;
 	createExtensionUIContext?:
 		| ((...args: unknown[]) => { notify?: ((...args: unknown[]) => unknown) | undefined })
@@ -38,6 +39,8 @@ interface InteractiveModeInstanceLike {
 		getText?: (() => string) | undefined;
 		setText?: ((text: string) => void) | undefined;
 	};
+	renderInitialMessages?: (() => void) | undefined;
+	rebuildChatFromMessages?: (() => void) | undefined;
 	executeCompaction?:
 		| ((customInstructions?: string, isAuto?: boolean) => Promise<unknown>)
 		| undefined;
@@ -84,6 +87,8 @@ interface InteractiveModePrototypeLike {
 	handleEvent?: ((event: InteractiveModeEventLike) => Promise<unknown>) | undefined;
 	handleReloadCommand?: ((...args: unknown[]) => Promise<unknown>) | undefined;
 	initExtensions?: ((...args: unknown[]) => Promise<unknown>) | undefined;
+	renderInitialMessages?: ((...args: unknown[]) => unknown) | undefined;
+	rebuildChatFromMessages?: ((...args: unknown[]) => unknown) | undefined;
 	setupKeyHandlers?: ((...args: unknown[]) => unknown) | undefined;
 	showSelector?: ((create: (...args: unknown[]) => unknown) => unknown) | undefined;
 }
@@ -96,6 +101,63 @@ interface InteractiveModePrototypeLike {
  */
 function resetRenderGrace(mode: InteractiveModeInstanceLike): void {
 	mode.ui?.resetRenderGrace?.();
+}
+
+interface SettingsListLike {
+	setLayoutTransitionCallback?: ((callback?: () => void) => void) | undefined;
+}
+
+interface SelectorCreateResultLike {
+	component?: unknown;
+	focus?: unknown;
+}
+
+/**
+ * Reset render grace and request a repaint for a large UI surface transition.
+ *
+ * @param mode - Interactive mode instance
+ * @returns Nothing
+ */
+function requestStableRender(mode: InteractiveModeInstanceLike): void {
+	resetRenderGrace(mode);
+	mode.ui?.requestRender?.();
+}
+
+/**
+ * Resolve a settings list instance from a selector result when available.
+ *
+ * @param result - Selector factory result
+ * @returns Settings list instance, or undefined when the selector is not settings-backed
+ */
+function getSettingsListFromSelectorResult(
+	result: SelectorCreateResultLike | undefined
+): SettingsListLike | undefined {
+	if (!result || typeof result !== "object") return undefined;
+	const focusCandidate = result.focus as SettingsListLike | undefined;
+	if (typeof focusCandidate?.setLayoutTransitionCallback === "function") {
+		return focusCandidate;
+	}
+	const componentCandidate = result.component as
+		| { getSettingsList?: (() => SettingsListLike | undefined) | undefined }
+		| undefined;
+	return componentCandidate?.getSettingsList?.();
+}
+
+/**
+ * Install render-stabilization hooks for settings submenu transitions.
+ *
+ * @param mode - Interactive mode instance
+ * @param result - Selector factory result
+ * @returns Nothing
+ */
+function bindSettingsLayoutTransitions(
+	mode: InteractiveModeInstanceLike,
+	result: SelectorCreateResultLike | undefined
+): void {
+	const settingsList = getSettingsListFromSelectorResult(result);
+	settingsList?.setLayoutTransitionCallback?.(() => {
+		requestStableRender(mode);
+	});
 }
 
 const APPLY_FLAG = "__tallow_interactive_stale_ui_patch_applied__";
@@ -639,6 +701,28 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 		};
 	}
 
+	const originalRenderInitialMessages = prototype.renderInitialMessages;
+	if (typeof originalRenderInitialMessages === "function") {
+		prototype.renderInitialMessages = function (
+			this: InteractiveModeInstanceLike,
+			...args: unknown[]
+		) {
+			requestStableRender(this);
+			return originalRenderInitialMessages.call(this, ...args);
+		};
+	}
+
+	const originalRebuildChatFromMessages = prototype.rebuildChatFromMessages;
+	if (typeof originalRebuildChatFromMessages === "function") {
+		prototype.rebuildChatFromMessages = function (
+			this: InteractiveModeInstanceLike,
+			...args: unknown[]
+		) {
+			requestStableRender(this);
+			return originalRebuildChatFromMessages.call(this, ...args);
+		};
+	}
+
 	const originalHandleEvent = prototype.handleEvent;
 	if (typeof originalHandleEvent === "function") {
 		prototype.handleEvent = async function (
@@ -845,12 +929,13 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 			return originalShowSelector.call(this, (...args: unknown[]) => {
 				const originalDone = args[0] as (() => void) | undefined;
 				const wrappedDone = () => {
-					resetRenderGrace(this);
+					requestStableRender(this);
 					originalDone?.();
-					this.ui?.requestRender?.();
 				};
-				resetRenderGrace(this);
-				return create(wrappedDone);
+				requestStableRender(this);
+				const result = create(wrappedDone) as SelectorCreateResultLike | undefined;
+				bindSettingsLayoutTransitions(this, result);
+				return result;
 			});
 		};
 	}


### PR DESCRIPTION
## Summary
- stabilize settings/thinking-level redraws by resetting render grace for settings submenu transitions and shared chat rebuild paths
- remove blank space in the tasks widget by top-aligning the side-by-side background column and requiring a wider terminal before split layout
- harden packaged runtime wrappers so global installs no longer depend on `src/` being shipped, with regression coverage for published-package layout

## Changes Made
- add settings submenu layout transition hooks in `SettingsList` and bind them from `interactive-mode-patch`
- wrap `renderInitialMessages()` and `rebuildChatFromMessages()` with stable-render resets
- update tasks widget layout logic/tests and add runtime wrapper packaging regression tests

## Testing
- `bun test src/__tests__/runtime-wrappers.test.ts packages/tallow-tui/src/__tests__/settings-list.test.ts src/__tests__/interactive-mode-patch.test.ts extensions/tasks`
- `bun run typecheck`
- `cd packages/tallow-tui && bun run build && cd ../.. && bun run build`
- audited published and local packed artifacts via isolated `bun add -g` installs and direct extension imports