### PR TITLE
fix: anchor startup continue to the transcript tail

### DIFF
--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -761,18 +761,6 @@ describe("patchInteractiveModePrototype", () => {
 		expect(mode.forceRenderRequests).toBe(1);
 	});
 
-	it("skips initial history render for startup continue sessions", async () => {
-		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
-		const mode = new FakeInteractiveMode();
-		mode.session._sessionStartEvent = { reason: "resume" };
-		mode.sessionManager.getEntries = () => [{ type: "message" }];
-
-		await mode.init();
-
-		expect(mode.lifecycleCalls).not.toContain("renderInitialMessages");
-		expect(mode.forceRenderRequests).toBe(1);
-	});
-
 	it("suppresses startup chat noise while restoring an existing session", async () => {
 		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
 		const mode = new FakeInteractiveMode();

--- a/src/__tests__/interactive-resume-path.test.ts
+++ b/src/__tests__/interactive-resume-path.test.ts
@@ -151,7 +151,7 @@ afterEach(() => {
 });
 
 describe("interactive resume rendering", () => {
-	it("does not replay transcript lines during startup continue", async () => {
+	it("anchors startup continue to the visible transcript tail", async () => {
 		const scenarioSource = `
 			import { mkdtempSync, rmSync } from "node:fs";
 			import { tmpdir } from "node:os";
@@ -213,12 +213,12 @@ describe("interactive resume rendering", () => {
 		expect(result.code).toBe(0);
 		expect(result.stdout).toContain("HAS_PROMPT_00 false");
 		expect(result.stdout).toContain("HAS_PROMPT_05 false");
-		expect(result.stdout).toContain("HAS_PROMPT_16 false");
-		expect(result.stdout).toContain("HAS_PROMPT_17 false");
+		expect(result.stdout).toContain("HAS_PROMPT_16 true");
+		expect(result.stdout).toContain("HAS_PROMPT_17 true");
 		expect(result.stdout).toContain("HAS_CLEAR_SCREEN true");
 	}, 20_000);
 
-	it("does not replay clipboard transcript lines during startup continue in node runtime", async () => {
+	it("renders the current transcript tail during startup continue in node runtime", async () => {
 		const scenarioSource = `
 			import { mkdtempSync, rmSync } from "node:fs";
 			import { tmpdir } from "node:os";
@@ -316,7 +316,7 @@ describe("interactive resume rendering", () => {
 		expect(result.stderr).toBe("");
 		expect(result.code).toBe(0);
 		expect(result.stdout).toContain("PATCHED true");
-		expect(result.stdout).toContain("HAS_CLIPBOARD false");
+		expect(result.stdout).toContain("HAS_CLIPBOARD true");
 	}, 20_000);
 
 	it("does not replay transcript lines during resume redraw", async () => {

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -700,7 +700,6 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 			this: InteractiveModeInstanceLikeWithStartupNoise,
 			...args: unknown[]
 		) {
-			const isStartupResume = this.session?._sessionStartEvent?.reason === "resume";
 			const sessionManager = (
 				this as InteractiveModeInstanceLike & {
 					sessionManager?: {
@@ -719,9 +718,6 @@ export function patchInteractiveModePrototype(prototype: InteractiveModePrototyp
 				this.ui?.beginRenderBatch?.();
 				this.ui?.requestScrollbackClear?.();
 				resetRenderGrace(this);
-			}
-			if (isStartupResume && originalRenderInitialMessages) {
-				this.renderInitialMessages = () => {};
 			}
 			try {
 				const result = await originalInit.call(this, ...args);


### PR DESCRIPTION
## Summary
- keep the existing transcript visible on `tallow -c` startup instead of opening into an empty middle state
- preserve the no-replay behavior while restoring the natural bottom-anchored viewport
- align the startup continue regressions with the behavior you actually want

## Changes Made
- stop suppressing the initial history render during startup continue/resume batching
- keep startup noise suppression and full redraw batching in place
- update interactive startup tests to assert visible transcript tail anchoring instead of an empty restore screen

## Testing
- `bun run build`
- `bun run typecheck`
- `bun run typecheck:extensions`
- `bun run lint`
- `bun test src/__tests__/interactive-mode-patch.test.ts`
- `bun test src/__tests__/interactive-resume-path.test.ts`
- `bun test`
- real PTY capture of `/opt/homebrew/bin/tallow -c`
