### PR TITLE
fix(ci): unblock release publishing on GitHub runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm (OIDC requires 11.5.1+)
-        run: npm install -g npm@latest
 
       - run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- stop the release publish job from self-updating npm on GitHub runners
- use Node 24 in the publish job so npm 11+ is available without mutating the runner installation
- unblock npm publishing for the pending 0.9.6 release

## Changes Made
- switch `.github/workflows/release.yml` publish job from Node 22 to Node 24
- remove the `npm install -g npm@latest` step that broke the 0.9.5 publish run with `Cannot find module 'promise-retry'`

## Testing
- `gh run view 24527248037 --log-failed` to confirm the 0.9.5 publish failure source
- `gh workflow view .github/workflows/release.yml`
