### PR TITLE
fix(rewind): prune stale snapshot refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
+  tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
+  transition compatibility hooks during the upgrade
+- **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
+  config so dependency bumps continue to build and validate cleanly
+- **interactive:** stabilize settings submenu transitions so changing thinking
+  level no longer triggers chat re-append jitter or viewport jumps
+- **interactive:** reset render grace before chat rebuild paths
+  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
+  churn across reload, fork, navigation, and settings-driven rebuilds
+- **rewind:** prune stale snapshot refs for deleted sessions on startup so
+  internal git checkpoints stop accumulating forever
+- **runtime:** remove published runtime wrapper references to `src/`, making
+  global installs resilient when only `runtime/` and `dist/` are shipped
+- **tasks:** top-align the side-by-side background column and require a wider
+  terminal before using split layout, removing large blank gaps above
+  background task content
+
 ## [0.9.6](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.5...tallow-v0.9.6) (2026-04-20)
 
 
@@ -46,26 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **git:** ignore local package bundles ([0015ead](https://github.com/dungle-scrubs/tallow/commit/0015ead124ab164c0ea11b4ffd79a4c1c895dd97))
 * **sonar:** refresh baseline on main pushes ([57281db](https://github.com/dungle-scrubs/tallow/commit/57281dbef977e5032c59351b21459ec653a4ac3e))
 * **tui:** move settings-list transition coverage to core patches ([d0f1f9d](https://github.com/dungle-scrubs/tallow/commit/d0f1f9d90c259d86cc17f0825a6597c296c399b1))
-
-## [Unreleased]
-
-### Fixed
-
-- **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
-  tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
-  transition compatibility hooks during the upgrade
-- **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
-  config so dependency bumps continue to build and validate cleanly
-- **interactive:** stabilize settings submenu transitions so changing thinking
-  level no longer triggers chat re-append jitter or viewport jumps
 - **interactive:** reset render grace before chat rebuild paths
-  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
-  churn across reload, fork, navigation, and settings-driven rebuilds
-- **runtime:** remove published runtime wrapper references to `src/`, making
-  global installs resilient when only `runtime/` and `dist/` are shipped
-- **tasks:** top-align the side-by-side background column and require a wider
-  terminal before using split layout, removing large blank gaps above
-  background task content
 
 ## [0.9.5](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.4...tallow-v0.9.5) (2026-04-16)
 

--- a/docs/src/content/docs/extensions/rewind.mdx
+++ b/docs/src/content/docs/extensions/rewind.mdx
@@ -49,6 +49,11 @@ collision with user refs, stashes, or other tools. Snapshot metadata is
 persisted in the session via custom entries, surviving session reloads and
 compaction.
 
+Rewind refs are intentionally **not** deleted on normal shutdown because a
+resumed session still needs them. Instead, rewind prunes refs for sessions
+whose backing session files no longer exist the next time a session starts in
+that repository.
+
 ## Why git refs?
 
 - **Random access** — Unlike stashes (LIFO), refs give O(1) access to any

--- a/extensions/rewind/__tests__/session-files.test.ts
+++ b/extensions/rewind/__tests__/session-files.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listLiveSessionIdsForCwd } from "../session-files.js";
+
+/**
+ * Encode a cwd into the session directory name used by tallow.
+ *
+ * @param cwd - Absolute working directory path
+ * @returns Encoded directory name
+ */
+function encodeSessionDirName(cwd: string): string {
+	const withoutLeadingSlash = cwd.startsWith("/") || cwd.startsWith("\\") ? cwd.slice(1) : cwd;
+	const safeName = withoutLeadingSlash
+		.replaceAll("/", "-")
+		.replaceAll("\\", "-")
+		.replaceAll(":", "-");
+	return `--${safeName}--`;
+}
+
+/**
+ * Create a minimal JSONL session file for a test home/cwd pair.
+ *
+ * @param homeDir - Tallow home directory
+ * @param cwd - Session working directory
+ * @param sessionId - Session id to persist in the header
+ * @param fileName - Session filename to create
+ * @returns Absolute path to the created session file
+ */
+function createSessionFile(
+	homeDir: string,
+	cwd: string,
+	sessionId: string,
+	fileName: string
+): string {
+	const sessionDir = join(homeDir, "sessions", encodeSessionDirName(cwd));
+	mkdirSync(sessionDir, { recursive: true });
+	const filePath = join(sessionDir, fileName);
+	writeFileSync(
+		filePath,
+		`${JSON.stringify({ cwd, id: sessionId, timestamp: new Date().toISOString(), type: "session", version: 3 })}\n`
+	);
+	return filePath;
+}
+
+describe("listLiveSessionIdsForCwd", () => {
+	const originalHome = process.env.HOME;
+	const originalTallowHome = process.env.TALLOW_CODING_AGENT_DIR;
+	const originalPiHome = process.env.PI_CODING_AGENT_DIR;
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "rewind-session-files-"));
+		process.env.HOME = tmpRoot;
+		delete process.env.PI_CODING_AGENT_DIR;
+		delete process.env.TALLOW_CODING_AGENT_DIR;
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+
+		if (originalTallowHome === undefined) {
+			delete process.env.TALLOW_CODING_AGENT_DIR;
+		} else {
+			process.env.TALLOW_CODING_AGENT_DIR = originalTallowHome;
+		}
+
+		if (originalPiHome === undefined) {
+			delete process.env.PI_CODING_AGENT_DIR;
+		} else {
+			process.env.PI_CODING_AGENT_DIR = originalPiHome;
+		}
+
+		rmSync(tmpRoot, { force: true, recursive: true });
+	});
+
+	it("finds live session ids across the default and active tallow homes", () => {
+		const cwd = "/Users/kevin/dev/tallow";
+		const defaultHome = join(tmpRoot, ".tallow");
+		const activeHome = join(tmpRoot, ".tallow-project");
+		process.env.TALLOW_CODING_AGENT_DIR = activeHome;
+
+		createSessionFile(defaultHome, cwd, "default-session", "2026-04-20_default-session.jsonl");
+		createSessionFile(activeHome, cwd, "active-session", "2026-04-20_active-session.jsonl");
+		createSessionFile(
+			activeHome,
+			"/Users/kevin/dev/other",
+			"other-project",
+			"2026-04-20_other.jsonl"
+		);
+
+		const ids = listLiveSessionIdsForCwd(cwd, [defaultHome, activeHome]);
+		expect([...ids].sort((a, b) => a.localeCompare(b))).toEqual([
+			"active-session",
+			"default-session",
+		]);
+	});
+
+	it("ignores unreadable or corrupt session files", () => {
+		const cwd = "/Users/kevin/dev/tallow";
+		const defaultHome = join(tmpRoot, ".tallow");
+		const sessionDir = join(defaultHome, "sessions", encodeSessionDirName(cwd));
+		mkdirSync(sessionDir, { recursive: true });
+		writeFileSync(join(sessionDir, "corrupt.jsonl"), "not-json\n");
+		createSessionFile(defaultHome, cwd, "valid-session", "2026-04-20_valid-session.jsonl");
+
+		const ids = listLiveSessionIdsForCwd(cwd, [defaultHome]);
+		expect([...ids]).toEqual(["valid-session"]);
+	});
+});

--- a/extensions/rewind/__tests__/snapshots.test.ts
+++ b/extensions/rewind/__tests__/snapshots.test.ts
@@ -247,6 +247,29 @@ describe("SnapshotManager", () => {
 		otherMgr.cleanup();
 	});
 
+	it("should prune stale session refs while preserving live sessions", () => {
+		const otherMgr = new SnapshotManager(tmpDir, "other-session");
+		const staleMgr = new SnapshotManager(tmpDir, "stale-session");
+
+		writeFileSync(join(tmpDir, "a.txt"), "live-1");
+		mgr.createSnapshot(1);
+		writeFileSync(join(tmpDir, "a.txt"), "live-2");
+		otherMgr.createSnapshot(1);
+		writeFileSync(join(tmpDir, "a.txt"), "stale");
+		staleMgr.createSnapshot(1);
+
+		const deletedRefs = mgr.cleanupStaleSessions(new Set(["other-session", "test-session"]));
+		expect(deletedRefs).toBe(1);
+
+		const staleRefs = git(["for-each-ref", "refs/tallow/rewind/stale-session/"], tmpDir);
+		expect(staleRefs.trim()).toBe("");
+
+		const liveRefs = git(["for-each-ref", "refs/tallow/rewind/test-session/"], tmpDir);
+		expect(liveRefs.trim()).not.toBe("");
+		const otherRefs = git(["for-each-ref", "refs/tallow/rewind/other-session/"], tmpDir);
+		expect(otherRefs.trim()).not.toBe("");
+	});
+
 	it("should return empty list when no snapshots exist", () => {
 		expect(mgr.listSnapshots()).toHaveLength(0);
 	});

--- a/extensions/rewind/index.ts
+++ b/extensions/rewind/index.ts
@@ -14,6 +14,7 @@
  */
 
 import type { CustomEntry, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { listLiveSessionIdsForCwd } from "./session-files.js";
 import { SnapshotManager } from "./snapshots.js";
 import type { RewindSnapshotEntry } from "./tracker.js";
 import { FileTracker } from "./tracker.js";
@@ -49,6 +50,10 @@ export default function rewind(pi: ExtensionAPI): void {
 		enabled = true;
 		snapshots = mgr;
 		tracker.reset();
+
+		const liveSessionIds = listLiveSessionIdsForCwd(context.cwd);
+		liveSessionIds.add(sessionId);
+		mgr.cleanupStaleSessions(liveSessionIds);
 
 		// Restore tracker state from persisted session entries
 		const entries = context.sessionManager.getEntries();

--- a/extensions/rewind/session-files.ts
+++ b/extensions/rewind/session-files.ts
@@ -1,0 +1,138 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { SessionHeader } from "@mariozechner/pi-coding-agent";
+import { getDefaultTallowHomeDir, getTallowHomeDir } from "../_shared/tallow-paths.js";
+
+/**
+ * Encode a cwd into the per-project session directory name used by tallow.
+ *
+ * @param cwd - Absolute working directory path
+ * @returns Encoded directory name (for example `--Users-kevin-dev-tallow--`)
+ */
+function encodeSessionDirName(cwd: string): string {
+	const withoutLeadingSlash = cwd.startsWith("/") || cwd.startsWith("\\") ? cwd.slice(1) : cwd;
+	const safeName = withoutLeadingSlash
+		.replaceAll("/", "-")
+		.replaceAll("\\", "-")
+		.replaceAll(":", "-");
+	return `--${safeName}--`;
+}
+
+/**
+ * Read additional tallow home directories from the maintainer's work-dir config.
+ *
+ * @returns Extra configured tallow home directories
+ */
+function readConfiguredHomeDirs(): string[] {
+	const workDirsPath = join(homedir(), ".config", "tallow-work-dirs");
+
+	try {
+		const content = readFileSync(workDirsPath, "utf-8");
+		return content
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#"))
+			.map((line) => {
+				const colonIndex = line.indexOf(":");
+				return colonIndex === -1 ? "" : line.slice(colonIndex + 1).trim();
+			})
+			.filter((configDir) => configDir.length > 0);
+	} catch {
+		// Missing or unreadable work-dir config means there are no extra homes to scan.
+		return [];
+	}
+}
+
+/**
+ * Build the set of tallow homes that should be searched for session files.
+ *
+ * @param homeDirs - Optional explicit home directories (used by tests to avoid scanning real homes)
+ * @returns Unique tallow home directories to inspect
+ */
+function resolveHomeDirs(homeDirs?: readonly string[]): Set<string> {
+	if (homeDirs) {
+		return new Set(homeDirs);
+	}
+
+	return new Set<string>([
+		getDefaultTallowHomeDir(),
+		getTallowHomeDir(),
+		...readConfiguredHomeDirs(),
+	]);
+}
+
+/**
+ * Discover every session directory that can contain sessions for a specific cwd.
+ *
+ * Tallow can store sessions under the default home, the active runtime home,
+ * and any per-project homes listed in `~/.config/tallow-work-dirs`.
+ *
+ * @param cwd - Working directory whose session subdirectory should be resolved
+ * @param homeDirs - Optional explicit home directories (used by tests to avoid scanning real homes)
+ * @returns Existing session directory paths across all known tallow homes
+ */
+function discoverSessionDirsForCwd(cwd: string, homeDirs?: readonly string[]): string[] {
+	const dirName = encodeSessionDirName(cwd);
+	const dirs = new Set<string>();
+
+	for (const home of resolveHomeDirs(homeDirs)) {
+		const sessionsDir = join(home, "sessions", dirName);
+		if (existsSync(sessionsDir)) {
+			dirs.add(sessionsDir);
+		}
+	}
+
+	return [...dirs];
+}
+
+/**
+ * Read the session id from a JSONL session file.
+ *
+ * The conventional filename already contains the id, but parsing the header is
+ * more robust for renamed or migrated session files.
+ *
+ * @param filePath - Absolute path to the session JSONL file
+ * @returns Session id when readable and valid, otherwise null
+ */
+function readSessionId(filePath: string): string | null {
+	try {
+		const content = readFileSync(filePath, "utf-8");
+		const firstNewline = content.indexOf("\n");
+		const headerLine = firstNewline === -1 ? content : content.slice(0, firstNewline);
+		const header = JSON.parse(headerLine) as SessionHeader;
+		if (header.type !== "session") return null;
+		return typeof header.id === "string" && header.id.length > 0 ? header.id : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * List every live session id for the current cwd across all known tallow homes.
+ *
+ * @param cwd - Working directory whose sessions should be considered live
+ * @param homeDirs - Optional explicit home directories to scan instead of runtime discovery
+ * @returns Set of live session ids
+ */
+export function listLiveSessionIdsForCwd(cwd: string, homeDirs?: readonly string[]): Set<string> {
+	const ids = new Set<string>();
+
+	for (const sessionsDir of discoverSessionDirsForCwd(cwd, homeDirs)) {
+		let files: string[];
+		try {
+			files = readdirSync(sessionsDir).filter((file) => file.endsWith(".jsonl"));
+		} catch {
+			continue;
+		}
+
+		for (const file of files) {
+			const sessionId = readSessionId(join(sessionsDir, file));
+			if (sessionId) {
+				ids.add(sessionId);
+			}
+		}
+	}
+
+	return ids;
+}

--- a/extensions/rewind/snapshots.ts
+++ b/extensions/rewind/snapshots.ts
@@ -277,13 +277,112 @@ export class SnapshotManager {
 	}
 
 	/**
-	 * Removes all refs for the current session.
+	 * Remove all refs for the current session.
+	 *
+	 * @returns Number of refs deleted for this session
 	 */
-	cleanup(): void {
-		const snapshots = this.listSnapshots();
-		for (const snap of snapshots) {
-			this.git(["update-ref", "-d", snap.ref]);
+	cleanup(): number {
+		return this.cleanupSession(this.getSessionIdFromPrefix(this.refPrefix));
+	}
+
+	/**
+	 * Remove rewind refs whose session ids no longer exist on disk.
+	 *
+	 * @param liveSessionIds - Session ids that still have backing session files
+	 * @returns Count of deleted refs across all stale sessions
+	 */
+	cleanupStaleSessions(liveSessionIds: ReadonlySet<string>): number {
+		let deletedRefs = 0;
+
+		for (const sessionId of this.listSessionIds()) {
+			if (liveSessionIds.has(sessionId)) continue;
+			deletedRefs += this.cleanupSession(sessionId);
 		}
+
+		return deletedRefs;
+	}
+
+	/**
+	 * List every session id that currently has rewind refs in this repository.
+	 *
+	 * @returns Ordered unique session ids extracted from `refs/tallow/rewind/*`
+	 */
+	private listSessionIds(): string[] {
+		const raw = this.git(["for-each-ref", "--format=%(refname)", "refs/tallow/rewind/"]);
+		if (!raw) return [];
+
+		const ids = new Set<string>();
+		for (const line of raw.split("\n")) {
+			const ref = this.normalizeRefName(line);
+			if (!ref) continue;
+			const sessionId = this.parseSessionIdFromRef(ref);
+			if (sessionId) {
+				ids.add(sessionId);
+			}
+		}
+
+		return [...ids].sort((a, b) => a.localeCompare(b));
+	}
+
+	/**
+	 * Remove every rewind ref for a single session id.
+	 *
+	 * @param sessionId - Session id whose namespaced rewind refs should be deleted
+	 * @returns Count of deleted refs
+	 */
+	private cleanupSession(sessionId: string): number {
+		const raw = this.git([
+			"for-each-ref",
+			"--format=%(refname)",
+			`refs/tallow/rewind/${sessionId}/`,
+		]);
+		if (!raw) return 0;
+
+		let deletedRefs = 0;
+		for (const line of raw.split("\n")) {
+			const ref = this.normalizeRefName(line);
+			if (!ref) continue;
+			if (this.git(["update-ref", "-d", ref]) !== null) {
+				deletedRefs++;
+			}
+		}
+
+		return deletedRefs;
+	}
+
+	/**
+	 * Parse a session id from a full rewind ref name.
+	 *
+	 * @param ref - Full rewind ref name
+	 * @returns Session id when the ref matches the rewind namespace, otherwise null
+	 */
+	private parseSessionIdFromRef(ref: string): string | null {
+		const match = /^refs\/tallow\/rewind\/([^/]+)\/turn-\d+$/.exec(ref);
+		return match?.[1] ?? null;
+	}
+
+	/**
+	 * Normalize a raw ref name line from git output.
+	 *
+	 * @param line - Raw line returned by `git for-each-ref`
+	 * @returns Trimmed ref name without surrounding quotes
+	 */
+	private normalizeRefName(line: string): string {
+		const trimmed = line.trim();
+		if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+			return trimmed.slice(1, -1);
+		}
+		return trimmed;
+	}
+
+	/**
+	 * Extract the current manager's session id from its ref prefix.
+	 *
+	 * @param refPrefix - Session-scoped rewind ref prefix
+	 * @returns Session id portion of the prefix
+	 */
+	private getSessionIdFromPrefix(refPrefix: string): string {
+		return refPrefix.replace(/^refs\/tallow\/rewind\//, "");
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- prune stale `refs/tallow/rewind/...` refs on session start instead of deleting snapshots on shutdown
- keep rewind snapshots valid for resumed sessions by only removing refs whose backing session files are gone
- add tests and docs for session-backed rewind ref garbage collection

## Changes Made
- add `extensions/rewind/session-files.ts` to discover live session ids for the current cwd across known tallow homes
- extend `SnapshotManager` with stale-session cleanup helpers and call them from `extensions/rewind/index.ts`
- add rewind tests plus docs/changelog updates

## Testing
- `bun test extensions/rewind`
- `bun run typecheck`
- `node tests/docs-drift.mjs`
- `node tests/changelog-structure.mjs`