### PR TITLE
fix(interactive): listen for the compaction events pi actually emits

### DIFF
--- a/src/__tests__/interactive-mode-patch.test.ts
+++ b/src/__tests__/interactive-mode-patch.test.ts
@@ -585,7 +585,7 @@ describe("patchInteractiveModePrototype", () => {
 
 		await withImmediateTimers(async () => {
 			const mode = new FakeInteractiveMode();
-			await mode.handleEvent({ type: "auto_compaction_end", willRetry: true });
+			await mode.handleEvent({ type: "compaction_end", willRetry: true });
 			await new Promise((resolve) => setTimeout(resolve, 10));
 
 			const warning = mode.notifyCalls.find(
@@ -600,7 +600,7 @@ describe("patchInteractiveModePrototype", () => {
 
 		await withImmediateTimers(async () => {
 			const mode = new FakeInteractiveMode();
-			await mode.handleEvent({ type: "auto_compaction_end", willRetry: true });
+			await mode.handleEvent({ type: "compaction_end", willRetry: true });
 			await mode.handleEvent({ type: "message_start" });
 			await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -615,7 +615,7 @@ describe("patchInteractiveModePrototype", () => {
 		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
 		const mode = new FakeInteractiveMode();
 
-		await mode.handleEvent({ type: "auto_compaction_end" });
+		await mode.handleEvent({ type: "compaction_end" });
 
 		const warning = mode.notifyCalls.find(
 			(call) => call.type === "warning" && call.message.includes("without a clear result")
@@ -627,9 +627,9 @@ describe("patchInteractiveModePrototype", () => {
 		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
 		const mode = new FakeInteractiveMode();
 
-		await mode.handleEvent({ result: { summary: "ok" }, type: "auto_compaction_end" });
-		await mode.handleEvent({ aborted: true, type: "auto_compaction_end" });
-		await mode.handleEvent({ errorMessage: "quota exceeded", type: "auto_compaction_end" });
+		await mode.handleEvent({ result: { summary: "ok" }, type: "compaction_end" });
+		await mode.handleEvent({ aborted: true, type: "compaction_end" });
+		await mode.handleEvent({ errorMessage: "quota exceeded", type: "compaction_end" });
 
 		const warning = mode.notifyCalls.find((call) =>
 			call.message.includes("without a clear result")
@@ -1214,7 +1214,7 @@ describe("patchInteractiveModePrototype", () => {
 		const mode = new FakeInteractiveMode();
 
 		// Start auto-compaction flow
-		await mode.handleEvent({ type: "auto_compaction_start" });
+		await mode.handleEvent({ type: "compaction_start" });
 		// agent_end arrives while compaction is still running
 		await mode.handleEvent({ type: "agent_end" });
 
@@ -1227,9 +1227,9 @@ describe("patchInteractiveModePrototype", () => {
 		const mode = new FakeInteractiveMode();
 
 		// Full compaction cycle completes (willRetry=false)
-		await mode.handleEvent({ type: "auto_compaction_start" });
+		await mode.handleEvent({ type: "compaction_start" });
 		await mode.handleEvent({
-			type: "auto_compaction_end",
+			type: "compaction_end",
 			willRetry: false,
 			result: { summary: "ok" },
 		});
@@ -1243,9 +1243,9 @@ describe("patchInteractiveModePrototype", () => {
 		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
 		const mode = new FakeInteractiveMode();
 
-		await mode.handleEvent({ type: "auto_compaction_start" });
+		await mode.handleEvent({ type: "compaction_start" });
 		// willRetry=true means the loader must survive until continuation actually starts
-		await mode.handleEvent({ type: "auto_compaction_end", willRetry: true });
+		await mode.handleEvent({ type: "compaction_end", willRetry: true });
 		await mode.handleEvent({ type: "agent_end" });
 
 		expect(mode.statusClears).toBe(0);
@@ -1255,8 +1255,8 @@ describe("patchInteractiveModePrototype", () => {
 		patchInteractiveModePrototype(FakeInteractiveMode.prototype as never);
 		const mode = new FakeInteractiveMode();
 
-		await mode.handleEvent({ type: "auto_compaction_start" });
-		await mode.handleEvent({ type: "auto_compaction_end", willRetry: true });
+		await mode.handleEvent({ type: "compaction_start" });
+		await mode.handleEvent({ type: "compaction_end", willRetry: true });
 		await mode.handleEvent({ type: "message_start" });
 		await mode.handleEvent({ type: "agent_end" });
 

--- a/src/interactive-mode-patch.ts
+++ b/src/interactive-mode-patch.ts
@@ -236,7 +236,7 @@ const COMPACTION_RETRY_STALLED_WARNING_TEXT =
 const AMBIGUOUS_COMPACTION_END_WARNING_TEXT =
 	"Auto-compaction ended without a clear result. Retry your last request, run /compact, or resend your message after reducing context.";
 
-/** Retry liveness timeout after auto_compaction_end before warning the user. */
+/** Retry liveness timeout after compaction_end before warning the user. */
 const COMPACTION_RETRY_WATCHDOG_TIMEOUT_MS = 2_500;
 
 const CONTINUATION_SIGNAL_EVENT_TYPES = new Set([
@@ -493,7 +493,7 @@ function clearCompactionRetryWatchdog(mode: InteractiveModeInstanceLike): void {
 }
 
 /**
- * Arms a retry-liveness watchdog after auto_compaction_end with willRetry=true.
+ * Arms a retry-liveness watchdog after compaction_end with willRetry=true.
  *
  * @param mode - Interactive mode instance
  * @returns Nothing
@@ -605,13 +605,13 @@ function drainOrphanedSessionMessages(mode: InteractiveModeInstanceLike): void {
 }
 
 /**
- * Returns whether auto_compaction_end finished without result, abort, or error.
+ * Returns whether compaction_end finished without result, abort, or error.
  *
  * @param event - Interactive mode event
  * @returns True when the compaction end state is ambiguous to users
  */
 function isAmbiguousCompactionEndState(event: InteractiveModeEventLike): boolean {
-	if (event.type !== "auto_compaction_end") return false;
+	if (event.type !== "compaction_end") return false;
 	if (event.willRetry === true) return false;
 	if (event.aborted === true) return false;
 	if (event.result !== null && event.result !== undefined) return false;
@@ -944,7 +944,7 @@ function applyPreHandleEventState(
 	mode: InteractiveModeInstanceLike,
 	event: InteractiveModeEventLike
 ): void {
-	if (event.type === "auto_compaction_start") {
+	if (event.type === "compaction_start") {
 		clearCompactionRetryWatchdog(mode);
 		markAutoCompactionRunning(mode);
 	}
@@ -961,7 +961,7 @@ function handleAutoCompactionEnd(
 	mode: InteractiveModeInstanceLike,
 	event: InteractiveModeEventLike
 ): void {
-	if (event.type !== "auto_compaction_end") {
+	if (event.type !== "compaction_end") {
 		return;
 	}
 	if (event.willRetry === true) {


### PR DESCRIPTION
## Summary

- Renames `auto_compaction_start`/`auto_compaction_end` to `compaction_start`/`compaction_end` in `interactive-mode-patch.ts` so the patch keys off the events pi-coding-agent actually emits (per `node_modules/@mariozechner/pi-coding-agent/dist/core/agent-session.d.ts`).
- Without the rename `markAutoCompactionRunning` never fired, so `shouldPreserveCompactionStatus` always returned false and the agent_end / getUserInput cleanup paths cleared the spinner upstream had just installed for overflow recovery. The retry-stalled watchdog also never armed.
- Updates the test event names so the suite exercises the real upstream payloads instead of validating the broken names.

## Test plan

- [x] `bun test src/__tests__/interactive-mode-patch.test.ts` — 46 pass
- [x] `bunx tsc --noEmit -p tsconfig.json` — clean
- [ ] Trigger a context overflow in the TUI and confirm the "Context overflow detected, Auto-compacting…" spinner stays visible until the retry begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)