### PR TITLE
feat(lsp): add TypeScript refactor tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
-
-
-### Fixed
-
-* **interactive:** listen for the compaction events pi actually emits ([5b833da](https://github.com/dungle-scrubs/tallow/commit/5b833dabb0dbb3a0b65787f077138f189fbb6ec6))
-
-## [0.9.7](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.6...tallow-v0.9.7) (2026-04-24)
-
-
-### Fixed
-
-* **git-status:** stop blocking prompt input ([542ca47](https://github.com/dungle-scrubs/tallow/commit/542ca47af84305d82258b4fa8cd6f4211c442cd8))
-* **rewind:** prune stale snapshot refs ([6e2d816](https://github.com/dungle-scrubs/tallow/commit/6e2d81696f1625542222ef2536f2c2631f3fb48f))
-
-
-### Maintenance
-
-* **deps:** adapt tallow to pi 0.70.0 ([ed91a84](https://github.com/dungle-scrubs/tallow/commit/ed91a843d545c94c5277e6911f4089fc0bb40584))
-* **deps:** bump pi-* dependencies ([7a813a9](https://github.com/dungle-scrubs/tallow/commit/7a813a9be6a83732263ce28139243c63aba9105b))
-
 ## [Unreleased]
+
+### Added
+
+- **lsp:** add editor-style TypeScript refactor tools for symbol rename,
+  file moves with import updates, and organize-imports dry-run previews
 
 ### Fixed
 
@@ -50,6 +34,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **tasks:** top-align the side-by-side background column and require a wider
   terminal before using split layout, removing large blank gaps above
   background task content
+
+## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
+
+
+### Fixed
+
+* **interactive:** listen for the compaction events pi actually emits ([5b833da](https://github.com/dungle-scrubs/tallow/commit/5b833dabb0dbb3a0b65787f077138f189fbb6ec6))
+
+## [0.9.7](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.6...tallow-v0.9.7) (2026-04-24)
+
+
+### Fixed
+
+* **git-status:** stop blocking prompt input ([542ca47](https://github.com/dungle-scrubs/tallow/commit/542ca47af84305d82258b4fa8cd6f4211c442cd8))
+* **rewind:** prune stale snapshot refs ([6e2d816](https://github.com/dungle-scrubs/tallow/commit/6e2d81696f1625542222ef2536f2c2631f3fb48f))
+
+
+### Maintenance
+
+* **deps:** adapt tallow to pi 0.70.0 ([ed91a84](https://github.com/dungle-scrubs/tallow/commit/ed91a843d545c94c5277e6911f4089fc0bb40584))
+* **deps:** bump pi-* dependencies ([7a813a9](https://github.com/dungle-scrubs/tallow/commit/7a813a9be6a83732263ce28139243c63aba9105b))
 
 ## [0.9.6](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.5...tallow-v0.9.6) (2026-04-20)
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ changes. Roll back to any earlier turn when something goes wrong.
 **Background tasks** — Kick off long-running work without blocking the session.
 Track task lifecycle explicitly and check back when ready.
 
-**LSP** — Jump to definitions, find references, inspect types, and search
-workspace symbols — no editor required.
+**LSP + refactors** — Jump to definitions, find references, inspect types,
+search workspace symbols, rename TypeScript symbols, move files with import
+updates, and organize imports — no editor required.
 
 **Claude Code compatible** — Projects with `.claude/` directories (skills, agents,
 commands) work without changes. Both `.tallow/` and `.claude/` are scanned;

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@sinclair/typebox": "0.34.49",
         "ai": "^6.0.162",
         "commander": "^14.0.3",
+        "typescript": "^6.0.2",
         "unpdf": "^1.6.0",
         "vscode-jsonrpc": "8.2.1",
         "vscode-languageserver-protocol": "3.17.5",
@@ -24,7 +25,6 @@
         "@types/node": "25.6.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
-        "typescript": "^6.0.2",
       },
     },
     "packages/tallow-tui": {

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **lsp:** add editor-style TypeScript refactor tools for symbol rename,
+  file moves with import updates, and organize-imports dry-run previews
+
 ### Fixed
 
 - **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
@@ -17,16 +22,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transition compatibility hooks during the upgrade
 - **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
   config so dependency bumps continue to build and validate cleanly
+- **git-status:** move git / GitHub status refreshes off the main thread and
+  add PR lookup backoff so slow `gh pr view` checks no longer freeze prompt
+  input while you type
 - **interactive:** stabilize settings submenu transitions so changing thinking
   level no longer triggers chat re-append jitter or viewport jumps
 - **interactive:** reset render grace before chat rebuild paths
   (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
   churn across reload, fork, navigation, and settings-driven rebuilds
+- **rewind:** prune stale snapshot refs for deleted sessions on startup so
+  internal git checkpoints stop accumulating forever
 - **runtime:** remove published runtime wrapper references to `src/`, making
   global installs resilient when only `runtime/` and `dist/` are shipped
 - **tasks:** top-align the side-by-side background column and require a wider
   terminal before using split layout, removing large blank gaps above
   background task content
+
+## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
+
+
+### Fixed
+
+* **interactive:** listen for the compaction events pi actually emits ([5b833da](https://github.com/dungle-scrubs/tallow/commit/5b833dabb0dbb3a0b65787f077138f189fbb6ec6))
+
+## [0.9.7](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.6...tallow-v0.9.7) (2026-04-24)
+
+
+### Fixed
+
+* **git-status:** stop blocking prompt input ([542ca47](https://github.com/dungle-scrubs/tallow/commit/542ca47af84305d82258b4fa8cd6f4211c442cd8))
+* **rewind:** prune stale snapshot refs ([6e2d816](https://github.com/dungle-scrubs/tallow/commit/6e2d81696f1625542222ef2536f2c2631f3fb48f))
+
+
+### Maintenance
+
+* **deps:** adapt tallow to pi 0.70.0 ([ed91a84](https://github.com/dungle-scrubs/tallow/commit/ed91a843d545c94c5277e6911f4089fc0bb40584))
+* **deps:** bump pi-* dependencies ([7a813a9](https://github.com/dungle-scrubs/tallow/commit/7a813a9be6a83732263ce28139243c63aba9105b))
+
+## [0.9.6](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.5...tallow-v0.9.6) (2026-04-20)
+
+
+### Fixed
+
+* **ci:** stop self-updating npm in release publish ([b698f20](https://github.com/dungle-scrubs/tallow/commit/b698f20193311d13bc396ec08f284a1700c2796a))
+* **context-fork:** ignore late fork completions after reset ([62483e4](https://github.com/dungle-scrubs/tallow/commit/62483e43d4f3f42b4779ce973cbff9b48e638f0d))
+* **deps:** override vulnerable transitive packages ([9486ee2](https://github.com/dungle-scrubs/tallow/commit/9486ee24d2f0c1153378ba567b25449de25b00da))
+* **interactive:** anchor continue startup to transcript tail ([96c73c8](https://github.com/dungle-scrubs/tallow/commit/96c73c85ba6f54c6cafe98539aff58613d21d0d8))
+* **interactive:** avoid forced redraws after normal turns ([94b5a28](https://github.com/dungle-scrubs/tallow/commit/94b5a283ed10de377806003bb17a7f9c16b461dd))
+* **interactive:** clear scrollback on session resets ([9675927](https://github.com/dungle-scrubs/tallow/commit/96759274ae70b2a3e6c920dadb4e03840609561c))
+* **interactive:** stop resume transcript replay on startup ([16c9fd0](https://github.com/dungle-scrubs/tallow/commit/16c9fd05c819b08e582018c93bf11727783d2769))
+* **reset:** complete clear and render regression hardening ([c506950](https://github.com/dungle-scrubs/tallow/commit/c506950e78d205991720881ae882afc827b84aa7))
+* **tui:** redraw only the visible viewport tail ([9bd4193](https://github.com/dungle-scrubs/tallow/commit/9bd4193f2503c10a5b851085cfa1abe86a0cc4fa))
+
+
+### Changed
+
+* **interactive:** reduce Sonar noise in startup patches ([5616a36](https://github.com/dungle-scrubs/tallow/commit/5616a36dc03f33596a35545669dc2b259c46e1b8))
+* **tui:** break TUI diff rendering into helpers ([9fbe459](https://github.com/dungle-scrubs/tallow/commit/9fbe459692cdf9c0f8656e13a46255322c624361))
+* **tui:** extract app-owned image and link helpers ([cc8baf7](https://github.com/dungle-scrubs/tallow/commit/cc8baf7bafac5a588c6c39b4068cc88442ebc92f))
+* **tui:** move editor and settings hooks out of the fork ([22feb7f](https://github.com/dungle-scrubs/tallow/commit/22feb7f813acf93a6ea9ed0f22a7b58dda36033d))
+* **tui:** move reset and render hooks out of the fork ([b6459c8](https://github.com/dungle-scrubs/tallow/commit/b6459c8cfd4825773c5469cb09af09a1b27b73e6))
+* **tui:** revert dead fork surfaces to upstream ([7c1176a](https://github.com/dungle-scrubs/tallow/commit/7c1176ae7929424284d65c6d19d9261ef89a9fdf))
+* **tui:** shrink input and selection drift ([5c6abfe](https://github.com/dungle-scrubs/tallow/commit/5c6abfe508468b92af8c2b421b925c9ed097d6cf))
+* **tui:** split editor and settings patches from pi-tui shim ([078cbc6](https://github.com/dungle-scrubs/tallow/commit/078cbc6d9bf11f5b5a46515459e57ebf241509ff))
+
+
+### Documentation
+
+* **changelog:** keep unreleased at the top ([d77caac](https://github.com/dungle-scrubs/tallow/commit/d77caac1ee42818b4f5a98a9f871f6bccdc595aa))
+* **plan:** add clear reset regression plan ([72dc402](https://github.com/dungle-scrubs/tallow/commit/72dc402078701571cc265bedd0a977636a556ee6))
+* **tui:** audit and document pi-tui fork drift ([5fc8515](https://github.com/dungle-scrubs/tallow/commit/5fc8515e0f6248ab89dbd3aee8cd37666e0b194e))
+
+
+### Maintenance
+
+* **clear:** prove reset cancels compact continuation ([ec4bb3e](https://github.com/dungle-scrubs/tallow/commit/ec4bb3ef6bece5f87942d1aff237057561f140d3))
+* **git:** ignore local package bundles ([0015ead](https://github.com/dungle-scrubs/tallow/commit/0015ead124ab164c0ea11b4ffd79a4c1c895dd97))
+* **sonar:** refresh baseline on main pushes ([57281db](https://github.com/dungle-scrubs/tallow/commit/57281dbef977e5032c59351b21459ec653a4ac3e))
+* **tui:** move settings-list transition coverage to core patches ([d0f1f9d](https://github.com/dungle-scrubs/tallow/commit/d0f1f9d90c259d86cc17f0825a6597c296c399b1))
+- **interactive:** reset render grace before chat rebuild paths
 
 ## [0.9.5](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.4...tallow-v0.9.5) (2026-04-16)
 

--- a/docs/src/content/docs/extensions/lsp.mdx
+++ b/docs/src/content/docs/extensions/lsp.mdx
@@ -6,13 +6,111 @@ description: Code intelligence via Language Server Protocol.
 Full LSP integration giving the agent precise code intelligence:
 go-to-definition, find all references, hover for type information,
 document symbols, and workspace-wide symbol search. Supports
-TypeScript, Python (ty/pyright), Rust, and Swift.
+TypeScript, Python (ty/pyright), Rust, Swift, and PHP.
+
+The extension also provides editor-style TypeScript refactor tools that
+request deterministic workspace edits from the TypeScript language
+service instead of relying on brittle search/replace workflows. Refactor
+tools default to dry-run previews and only write files when explicitly
+called with `dryRun: false`.
 
 After edits, diagnostics are automatically reported so the agent
 can catch type errors and lint issues without you asking.
 
 Startup and request operations are time-bounded with automatic cleanup,
 so stalled language servers fail fast instead of hanging a tool call.
+
+## Refactor tools
+
+### Rename a symbol everywhere
+
+Use `refactor_rename_symbol` to rename a function, class, variable, type,
+or export at a specific source position. It updates declarations,
+references, and import specifiers using TypeScript rename locations.
+
+```json
+{
+  "file": "src/hooks/use-bff-chat.ts",
+  "line": 12,
+  "character": 17,
+  "newName": "useChat"
+}
+```
+
+The default `dryRun: true` returns touched files, edit counts, and a
+unified diff-style preview. Apply the edit after reviewing the preview:
+
+```json
+{
+  "file": "src/hooks/use-bff-chat.ts",
+  "line": 12,
+  "character": 17,
+  "newName": "useChat",
+  "dryRun": false
+}
+```
+
+### Move a file and update imports
+
+Use `refactor_move_file` to move or rename a TypeScript/JavaScript file
+and update relative imports across the project using TypeScript's
+file-rename edits.
+
+```json
+{
+  "from": "src/bff/logger.ts",
+  "to": "src/orchestration/logger.ts"
+}
+```
+
+Apply after review:
+
+```json
+{
+  "from": "src/bff/logger.ts",
+  "to": "src/orchestration/logger.ts",
+  "dryRun": false
+}
+```
+
+The tool creates destination directories when applying and removes the
+old file. It does not leave compatibility copies.
+
+### Organize imports
+
+Use `refactor_organize_imports` after a large refactor to remove unused
+imports and normalize import ordering through TypeScript's source action.
+
+```json
+{
+  "dirs": ["src"],
+  "dryRun": true
+}
+```
+
+Then apply to selected files or directories:
+
+```json
+{
+  "dirs": ["src"],
+  "dryRun": false
+}
+```
+
+### Safety model
+
+Refactor tools:
+
+- default to `dryRun: true`
+- reject edits outside the current working directory
+- reject edits under `.git`, `node_modules`, `dist`, `build`, `out`,
+  `coverage`, and `vendor`
+- validate and reverse-apply text edits to avoid offset drift
+- reject overlapping edit spans
+- stage file contents in memory before writing
+- require `force: true` for large non-dry-run edits
+- return clear errors when TypeScript is unavailable or the position is
+  not renameable
 
 ## Configuration
 

--- a/docs/src/content/docs/extensions/overview.mdx
+++ b/docs/src/content/docs/extensions/overview.mdx
@@ -36,7 +36,7 @@ these categories:
 | **Commands** | 7 | command-prompt, command-expansion, context-fork, file-reference, health, shell-interpolation, skill-commands |
 | **Utilities** | 6 | cheatsheet, context-usage, debug, init, show-system-prompt, read-tool-enhanced |
 | **Integrations** | 3 | lifecycle hooks, claude-bridge, worktree |
-| **Language Support** | 1 | LSP |
+| **Language Support** | 1 | LSP code intelligence and TypeScript refactors |
 | **Context** | 1 | context-files |
 | **Dev** | 1 | upstream-check |
 | **Aliases** | 1 | /clear → /new |

--- a/extensions/lsp/__tests__/refactor-tools.test.ts
+++ b/extensions/lsp/__tests__/refactor-tools.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { ExtensionHarness } from "../../../test-utils/extension-harness.js";
+import lspExtension from "../index.js";
+import {
+	applyTextEdits,
+	setTypeScriptModuleForRefactorTests,
+	stageWorkspaceEdit,
+} from "../refactor.js";
+
+/**
+ * Creates a minimal context for refactor tool execution.
+ *
+ * @param cwd - Tool working directory
+ * @returns Extension context stub
+ */
+function createContext(cwd: string): ExtensionContext {
+	return {
+		cwd,
+		hasUI: false,
+		ui: { setWorkingMessage() {} },
+	} as unknown as ExtensionContext;
+}
+
+/**
+ * Writes a fixture file under a project root.
+ *
+ * @param root - Fixture project root
+ * @param relativePath - File path relative to root
+ * @param content - File contents
+ * @returns Absolute file path
+ */
+function writeFixture(root: string, relativePath: string, content: string): string {
+	const filePath = join(root, relativePath);
+	mkdirSync(dirname(filePath), { recursive: true });
+	writeFileSync(filePath, content, "utf-8");
+	return filePath;
+}
+
+/**
+ * Reads a fixture file as UTF-8.
+ *
+ * @param root - Fixture project root
+ * @param relativePath - File path relative to root
+ * @returns File contents
+ */
+function readFixture(root: string, relativePath: string): string {
+	return readFileSync(join(root, relativePath), "utf-8");
+}
+
+/**
+ * Looks up a registered tool and throws when missing.
+ *
+ * @param harness - Extension harness
+ * @param name - Tool name
+ * @returns Registered tool
+ */
+function getTool(harness: ExtensionHarness, name: string): ToolDefinition {
+	const tool = harness.tools.get(name);
+	if (!tool) throw new Error(`Expected tool ${name}`);
+	return tool;
+}
+
+/**
+ * Extracts the first text response from a tool result.
+ *
+ * @param result - Tool result
+ * @returns Text response
+ */
+function textOf(result: { content: Array<{ text?: string; type: string }> }): string {
+	const text = result.content.find((part) => part.type === "text")?.text;
+	if (!text) throw new Error("Expected text result");
+	return text;
+}
+
+/**
+ * Executes a registered tool with a default signal and noop update callback.
+ *
+ * @param tool - Tool to execute
+ * @param params - Tool parameters
+ * @param cwd - Working directory
+ * @returns Tool result
+ */
+async function executeTool(tool: ToolDefinition, params: object, cwd: string) {
+	return tool.execute(
+		"test-call",
+		params,
+		new AbortController().signal,
+		() => {},
+		createContext(cwd)
+	);
+}
+
+describe("refactor workspace edit helpers", () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		projectDir = mkdtempSync(join(tmpdir(), "tallow-refactor-helpers-"));
+	});
+
+	afterEach(() => {
+		rmSync(projectDir, { force: true, recursive: true });
+	});
+
+	test("applies multiple edits in reverse order", () => {
+		expect(
+			applyTextEdits("alpha beta gamma", [
+				{ end: 16, newText: "delta", start: 11 },
+				{ end: 5, newText: "omega", start: 0 },
+			])
+		).toBe("omega beta delta");
+	});
+
+	test("rejects overlapping edits", () => {
+		writeFixture(projectDir, "src/example.ts", "abcdef\n");
+		expect(() =>
+			stageWorkspaceEdit(projectDir, [
+				{
+					fileName: join(projectDir, "src/example.ts"),
+					textChanges: [
+						{ newText: "X", span: { length: 3, start: 1 } },
+						{ newText: "Y", span: { length: 3, start: 2 } },
+					],
+				},
+			])
+		).toThrow("Overlapping edits");
+	});
+
+	test("rejects edits outside the project root", () => {
+		expect(() =>
+			stageWorkspaceEdit(projectDir, [
+				{
+					fileName: join(projectDir, "..", "outside.ts"),
+					textChanges: [{ newText: "x", span: { length: 0, start: 0 } }],
+				},
+			])
+		).toThrow("outside project root");
+	});
+});
+
+describe("refactor TypeScript tools", () => {
+	let harness: ExtensionHarness;
+	let projectDir: string;
+
+	beforeEach(async () => {
+		projectDir = mkdtempSync(join(tmpdir(), "tallow-refactor-tools-"));
+		writeFixture(
+			projectDir,
+			"tsconfig.json",
+			JSON.stringify({
+				compilerOptions: { module: "ESNext", moduleResolution: "Bundler", target: "ES2022" },
+				include: ["src"],
+			})
+		);
+		harness = ExtensionHarness.create();
+		await harness.loadExtension(lspExtension);
+	});
+
+	afterEach(() => {
+		setTypeScriptModuleForRefactorTests();
+		harness.reset();
+		rmSync(projectDir, { force: true, recursive: true });
+	});
+
+	test("renames a symbol across declarations, references, and imports", async () => {
+		writeFixture(projectDir, "src/lib.ts", "export function useBffChat() {\n\treturn 'ok';\n}\n");
+		writeFixture(
+			projectDir,
+			"src/app.ts",
+			"import { useBffChat } from './lib';\n\nexport const result = useBffChat();\n"
+		);
+		const tool = getTool(harness, "refactor_rename_symbol");
+
+		const dryRun = await executeTool(
+			tool,
+			{ character: 17, file: "src/lib.ts", line: 1, newName: "useChat" },
+			projectDir
+		);
+		expect(dryRun.isError).toBeUndefined();
+		expect(textOf(dryRun)).toContain("Preview: 2 file(s)");
+		expect(readFixture(projectDir, "src/lib.ts")).toContain("useBffChat");
+
+		const applied = await executeTool(
+			tool,
+			{ character: 17, dryRun: false, file: "src/lib.ts", line: 1, newName: "useChat" },
+			projectDir
+		);
+		expect(applied.isError).toBeUndefined();
+		expect(readFixture(projectDir, "src/lib.ts")).toContain("useChat");
+		expect(readFixture(projectDir, "src/app.ts")).toContain("import { useChat } from './lib';");
+		expect(readFixture(projectDir, "src/app.ts")).toContain("useChat()");
+	});
+
+	test("moves a file and updates relative imports", async () => {
+		writeFixture(projectDir, "src/utils/constants.ts", "export const one = 1;\n");
+		writeFixture(
+			projectDir,
+			"src/utils/math.ts",
+			"import { one } from './constants';\n\nexport const add = (a: number, b: number) => a + b + one;\n"
+		);
+		writeFixture(
+			projectDir,
+			"src/app.ts",
+			"import { add } from './utils/math';\n\nexport const value = add(1, 2);\n"
+		);
+		const tool = getTool(harness, "refactor_move_file");
+
+		const dryRun = await executeTool(
+			tool,
+			{ from: "src/utils/math.ts", to: "src/lib/math.ts" },
+			projectDir
+		);
+		expect(dryRun.isError).toBeUndefined();
+		expect(textOf(dryRun)).toContain("src/lib/math.ts");
+		expect(readFixture(projectDir, "src/app.ts")).toContain("./utils/math");
+
+		const applied = await executeTool(
+			tool,
+			{ dryRun: false, from: "src/utils/math.ts", to: "src/lib/math.ts" },
+			projectDir
+		);
+		expect(applied.isError).toBeUndefined();
+		expect(readFixture(projectDir, "src/app.ts")).toContain("./lib/math");
+		expect(readFixture(projectDir, "src/lib/math.ts")).toContain("export const add");
+		expect(readFixture(projectDir, "src/lib/math.ts")).toContain("../utils/constants");
+		expect(() => readFixture(projectDir, "src/utils/math.ts")).toThrow();
+	});
+
+	test("organizes imports with dry-run preview and apply", async () => {
+		writeFixture(projectDir, "src/a.ts", "export const a = 1;\n");
+		writeFixture(projectDir, "src/b.ts", "export const b = 2;\n");
+		writeFixture(
+			projectDir,
+			"src/app.ts",
+			"import { b } from './b';\nimport { a } from './a';\nimport { missing } from './missing';\n\nconsole.log(a);\n"
+		);
+		const tool = getTool(harness, "refactor_organize_imports");
+
+		const dryRun = await executeTool(tool, { files: ["src/app.ts"] }, projectDir);
+		expect(dryRun.isError).toBeUndefined();
+		expect(textOf(dryRun)).toContain("Preview: 1 file(s)");
+		expect(readFixture(projectDir, "src/app.ts")).toContain("missing");
+
+		const applied = await executeTool(tool, { dryRun: false, files: ["src/app.ts"] }, projectDir);
+		expect(applied.isError).toBeUndefined();
+		expect(readFixture(projectDir, "src/app.ts")).not.toContain("missing");
+		expect(readFixture(projectDir, "src/app.ts")).not.toContain("./b");
+	});
+
+	test("requires force for excessive apply edits", async () => {
+		writeFixture(projectDir, "src/lib.ts", "export function useBffChat() {\n\treturn 'ok';\n}\n");
+		writeFixture(
+			projectDir,
+			"src/app.ts",
+			`import { useBffChat } from './lib';\n\n${Array.from({ length: 251 }, (_, index) => `export const result${index} = useBffChat();`).join("\n")}\n`
+		);
+		const tool = getTool(harness, "refactor_rename_symbol");
+
+		const blocked = await executeTool(
+			tool,
+			{ character: 17, dryRun: false, file: "src/lib.ts", line: 1, newName: "useChat" },
+			projectDir
+		);
+		expect(blocked.isError).toBe(true);
+		expect(textOf(blocked)).toContain("force:true");
+		expect(readFixture(projectDir, "src/app.ts")).toContain("useBffChat");
+	});
+
+	test("reports missing TypeScript clearly", async () => {
+		writeFixture(projectDir, "src/lib.ts", "export const value = 1;\n");
+		setTypeScriptModuleForRefactorTests(new Error("TypeScript is required for refactor tools"));
+		const tool = getTool(harness, "refactor_rename_symbol");
+
+		const result = await executeTool(
+			tool,
+			{ character: 14, file: "src/lib.ts", line: 1, newName: "renamed" },
+			projectDir
+		);
+		expect(result.isError).toBe(true);
+		expect(textOf(result)).toContain("TypeScript is required");
+	});
+
+	test("fails safely for invalid rename inputs and outside paths", async () => {
+		writeFixture(projectDir, "src/lib.ts", "export const value = 1;\n");
+		const renameTool = getTool(harness, "refactor_rename_symbol");
+		const moveTool = getTool(harness, "refactor_move_file");
+
+		const invalidName = await executeTool(
+			renameTool,
+			{ character: 14, dryRun: false, file: "src/lib.ts", line: 1, newName: "bad-name" },
+			projectDir
+		);
+		expect(invalidName.isError).toBe(true);
+		expect(readFixture(projectDir, "src/lib.ts")).toContain("value");
+
+		const outside = await executeTool(
+			moveTool,
+			{ dryRun: false, from: "src/lib.ts", to: "../lib.ts" },
+			projectDir
+		);
+		expect(outside.isError).toBe(true);
+		expect(textOf(outside)).toContain("outside project root");
+	});
+});

--- a/extensions/lsp/extension.json
+++ b/extensions/lsp/extension.json
@@ -1,8 +1,8 @@
 {
 	"name": "lsp",
 	"version": "0.1.0",
-	"description": "Language Server Protocol support — jump to definition, references, hover, symbols",
-	"whenToUse": "Use when you want language-intelligence tools like hover, definition, references, and symbols.",
+	"description": "Language Server Protocol support plus editor-style TypeScript refactor tools",
+	"whenToUse": "Use when you want language-intelligence tools or safe TypeScript refactors like rename symbol, move file, and organize imports.",
 	"capabilities": {
 		"tools": [
 			"lsp_definition",
@@ -10,21 +10,25 @@
 			"lsp_references",
 			"lsp_status",
 			"lsp_symbols",
-			"lsp_workspace_symbols"
+			"lsp_workspace_symbols",
+			"refactor_move_file",
+			"refactor_organize_imports",
+			"refactor_rename_symbol"
 		],
 		"events": ["session_shutdown"]
 	},
 	"permissionSurface": {
-		"filesystem": "read",
+		"filesystem": "write",
 		"shell": false,
 		"network": false,
 		"subprocess": true
 	},
 	"category": "language-support",
-	"tags": ["lsp", "code-intelligence"],
-	"files": ["index.ts", "types.d.ts"],
+	"tags": ["lsp", "code-intelligence", "refactor", "typescript"],
+	"files": ["index.ts", "refactor.ts", "types.d.ts"],
 	"relationships": [],
 	"npmDependencies": {
+		"typescript": "^6.0.2",
 		"vscode-languageserver-protocol": "^3.17.5",
 		"vscode-jsonrpc": "^8.2.0"
 	}

--- a/extensions/lsp/index.ts
+++ b/extensions/lsp/index.ts
@@ -41,6 +41,7 @@ import {
 } from "vscode-languageserver-protocol";
 import { getIcon } from "../_icons/index.js";
 import { getTallowSettingsPath } from "../_shared/tallow-paths.js";
+import { registerRefactorTools } from "./refactor.js";
 
 /** Language server binary configuration and project detection markers. */
 interface ServerConfig {
@@ -1097,6 +1098,8 @@ export default function lspExtension(pi: ExtensionAPI) {
 	const registerTool = (tool: unknown): void => {
 		pi.registerTool(tool as Parameters<ExtensionAPI["registerTool"]>[0]);
 	};
+
+	registerRefactorTools(registerTool);
 
 	// Tool: Go to Definition
 	registerTool({

--- a/extensions/lsp/refactor.ts
+++ b/extensions/lsp/refactor.ts
@@ -1,0 +1,1012 @@
+/**
+ * Editor-style TypeScript refactor helpers for the LSP extension.
+ *
+ * The implementation uses the TypeScript language-service APIs directly. Those
+ * are the same deterministic primitives tsserver exposes to editors for rename,
+ * file-rename import updates, and organize-imports actions.
+ */
+
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+const require = createRequire(import.meta.url);
+const LARGE_EDIT_FILE_LIMIT = 25;
+const LARGE_EDIT_COUNT_LIMIT = 250;
+const VENDOR_SEGMENTS = new Set([
+	".git",
+	"node_modules",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+	"vendor",
+]);
+
+interface TypeScriptModule {
+	createLanguageService(host: LanguageServiceHost): LanguageService;
+	findConfigFile(
+		searchPath: string,
+		fileExists: (fileName: string) => boolean,
+		configName?: string
+	): string | undefined;
+	flattenDiagnosticMessageText(messageText: unknown, newLine: string): string;
+	getDefaultLibFilePath(options: CompilerOptions): string;
+	getLineAndCharacterOfPosition(sourceFile: SourceFile, position: number): LineAndCharacter;
+	readConfigFile(
+		fileName: string,
+		readFile: (fileName: string) => string | undefined
+	): ReadConfigFileResult;
+	ScriptSnapshot: { fromString(text: string): ScriptSnapshot };
+	ScriptTarget: { Latest: number };
+	sys: {
+		fileExists(fileName: string): boolean;
+		readDirectory: (...args: unknown[]) => string[];
+		readFile(fileName: string): string | undefined;
+		useCaseSensitiveFileNames: boolean;
+	};
+	parseJsonConfigFileContent(
+		config: unknown,
+		host: ParseConfigHost,
+		basePath: string
+	): ParsedCommandLine;
+}
+
+interface CompilerOptions {
+	readonly [key: string]: unknown;
+}
+
+interface DiagnosticLike {
+	readonly messageText: unknown;
+}
+
+interface LineAndCharacter {
+	readonly character: number;
+	readonly line: number;
+}
+
+interface LanguageService {
+	dispose(): void;
+	findRenameLocations(
+		fileName: string,
+		position: number,
+		findInStrings: boolean,
+		findInComments: boolean,
+		providePrefixAndSuffixTextForRename: boolean
+	): readonly RenameLocation[] | undefined;
+	getEditsForFileRename(
+		oldFilePath: string,
+		newFilePath: string,
+		formatOptions: Record<string, never>,
+		preferences: Record<string, unknown> | undefined
+	): readonly FileTextChanges[];
+	getProgram(): Program | undefined;
+	getRenameInfo(fileName: string, position: number): RenameInfo;
+	organizeImports(
+		scope: { fileName: string; type: "file" },
+		formatOptions: Record<string, never>,
+		preferences: Record<string, unknown>
+	): readonly FileTextChanges[];
+}
+
+interface LanguageServiceHost {
+	directoryExists?(directoryName: string): boolean;
+	fileExists(fileName: string): boolean;
+	getCompilationSettings(): CompilerOptions;
+	getCurrentDirectory(): string;
+	getDefaultLibFileName(options: CompilerOptions): string;
+	getScriptFileNames(): string[];
+	getScriptSnapshot(fileName: string): ScriptSnapshot | undefined;
+	getScriptVersion(fileName: string): string;
+	readDirectory: (...args: unknown[]) => string[];
+	readFile(fileName: string): string | undefined;
+	useCaseSensitiveFileNames(): boolean;
+}
+
+interface ParseConfigHost {
+	fileExists(fileName: string): boolean;
+	readDirectory: (...args: unknown[]) => string[];
+	readFile(fileName: string): string | undefined;
+	useCaseSensitiveFileNames: boolean;
+}
+
+interface ParsedCommandLine {
+	readonly errors: readonly DiagnosticLike[];
+	readonly fileNames: readonly string[];
+	readonly options: CompilerOptions;
+}
+
+interface Program {
+	getSourceFile(fileName: string): SourceFile | undefined;
+}
+
+interface ReadConfigFileResult {
+	readonly config?: unknown;
+	readonly error?: DiagnosticLike;
+}
+
+interface RenameInfo {
+	readonly canRename: boolean;
+	readonly displayName?: string;
+	readonly fullDisplayName?: string;
+	readonly localizedErrorMessage?: string;
+	readonly triggerSpan?: TextSpan;
+}
+
+interface RenameLocation {
+	readonly fileName: string;
+	readonly prefixText?: string;
+	readonly suffixText?: string;
+	readonly textSpan: TextSpan;
+}
+
+type ScriptSnapshot = unknown;
+
+interface SourceFile {
+	readonly text: string;
+}
+
+interface TextChange {
+	readonly newText: string;
+	readonly span: TextSpan;
+}
+
+interface FileTextChanges {
+	readonly fileName: string;
+	readonly isNewFile?: boolean;
+	readonly textChanges: readonly TextChange[];
+}
+
+interface TextSpan {
+	readonly length: number;
+	readonly start: number;
+}
+
+interface TextEdit {
+	readonly end: number;
+	readonly newText: string;
+	readonly start: number;
+}
+
+interface FileEditSet {
+	readonly edits: readonly TextEdit[];
+	readonly originalText: string;
+}
+
+interface StagedWorkspaceEdit {
+	readonly editCount: number;
+	readonly files: ReadonlyMap<string, FileEditSet>;
+	readonly root: string;
+}
+
+interface StagedFileSystemChange {
+	readonly createdFiles: readonly string[];
+	readonly deletedFiles: readonly string[];
+	readonly edit: StagedWorkspaceEdit;
+	readonly nextContents: ReadonlyMap<string, string>;
+}
+
+interface RefactorToolResultDetails {
+	readonly dryRun: boolean;
+	readonly editCount: number;
+	readonly touchedFiles: readonly string[];
+}
+
+let typescriptModuleOverride: Error | TypeScriptModule | null = null;
+
+/**
+ * Overrides the TypeScript module resolver in tests.
+ *
+ * @param ts - Replacement TypeScript module, or undefined to restore runtime resolution
+ * @returns Nothing
+ */
+export function setTypeScriptModuleForRefactorTests(ts?: Error | TypeScriptModule): void {
+	typescriptModuleOverride = ts ?? null;
+}
+
+/**
+ * Registers editor-style refactor tools on the LSP extension.
+ *
+ * @param registerTool - Existing registerTool bridge from the LSP extension
+ * @returns Nothing
+ */
+export function registerRefactorTools(registerTool: (tool: unknown) => void): void {
+	registerTool({
+		name: "refactor_rename_symbol",
+		label: "refactor_rename_symbol",
+		description: `Rename a symbol everywhere using the TypeScript language service.
+
+Dry-run defaults to true and returns touched files plus a preview. Set dryRun:false to apply.`,
+		parameters: Type.Object({
+			file: Type.String({ description: "Path to the file containing the symbol" }),
+			line: Type.Number({ description: "Line number (1-indexed)" }),
+			character: Type.Number({ description: "Character/column position (1-indexed)" }),
+			newName: Type.String({ description: "New symbol name" }),
+			dryRun: Type.Optional(Type.Boolean({ description: "Preview only (default: true)" })),
+			force: Type.Optional(Type.Boolean({ description: "Allow large edits on apply" })),
+		}),
+		async execute(
+			_toolCallId: string,
+			params: {
+				character: number;
+				dryRun?: boolean;
+				file: string;
+				force?: boolean;
+				line: number;
+				newName: string;
+			},
+			_signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			ctx: ExtensionContext
+		) {
+			try {
+				const dryRun = params.dryRun ?? true;
+				const root = normalizeRoot(ctx.cwd);
+				const filePath = resolveSafePath(root, params.file);
+				validateIdentifier(params.newName);
+				const ts = loadTypeScript(filePath);
+				const service = createProjectService(ts, root, filePath);
+
+				try {
+					const sourceFile = service.getProgram()?.getSourceFile(filePath);
+					if (!sourceFile) {
+						return errorResult(`TypeScript could not load ${path.relative(root, filePath)}`);
+					}
+					const position = positionFromLineCharacter(
+						sourceFile.text,
+						params.line,
+						params.character
+					);
+					const renameInfo = service.getRenameInfo(filePath, position);
+					if (!renameInfo.canRename) {
+						return errorResult(
+							renameInfo.localizedErrorMessage ?? "No renameable symbol at position"
+						);
+					}
+
+					const locations = service.findRenameLocations(filePath, position, false, false, true);
+					if (!locations || locations.length === 0) {
+						return errorResult("No rename locations returned for symbol");
+					}
+
+					const staged = stageWorkspaceEdit(
+						root,
+						locations.map((location) => ({
+							fileName: location.fileName,
+							textChanges: [
+								{
+									newText: `${location.prefixText ?? ""}${params.newName}${location.suffixText ?? ""}`,
+									span: location.textSpan,
+								},
+							],
+						}))
+					);
+
+					return finalizeTextOnlyChange(staged, { dryRun, force: params.force ?? false });
+				} finally {
+					service.dispose();
+				}
+			} catch (error) {
+				return errorResult(error instanceof Error ? error.message : String(error));
+			}
+		},
+	});
+
+	registerTool({
+		name: "refactor_move_file",
+		label: "refactor_move_file",
+		description: `Move or rename a TypeScript/JavaScript file and update imports using the TypeScript language service.
+
+Dry-run defaults to true and returns touched files plus a preview. Set dryRun:false to apply.`,
+		parameters: Type.Object({
+			from: Type.String({ description: "Source file path" }),
+			to: Type.String({ description: "Destination file path" }),
+			updateImports: Type.Optional(Type.Boolean({ description: "Update imports (default: true)" })),
+			dryRun: Type.Optional(Type.Boolean({ description: "Preview only (default: true)" })),
+			force: Type.Optional(Type.Boolean({ description: "Allow large edits on apply" })),
+		}),
+		async execute(
+			_toolCallId: string,
+			params: {
+				dryRun?: boolean;
+				force?: boolean;
+				from: string;
+				to: string;
+				updateImports?: boolean;
+			},
+			_signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			ctx: ExtensionContext
+		) {
+			try {
+				const dryRun = params.dryRun ?? true;
+				const root = normalizeRoot(ctx.cwd);
+				const from = resolveSafePath(root, params.from);
+				const to = resolveSafePath(root, params.to);
+				if (!fs.existsSync(from)) return errorResult(`Source file does not exist: ${params.from}`);
+				if (fs.existsSync(to)) return errorResult(`Destination already exists: ${params.to}`);
+
+				const ts = loadTypeScript(from);
+				const service = createProjectService(ts, root, from);
+				try {
+					const edits =
+						params.updateImports === false ? [] : service.getEditsForFileRename(from, to, {}, {});
+					const staged = stageFileMove(root, from, to, edits);
+					return finalizeFileSystemChange(staged, { dryRun, force: params.force ?? false });
+				} finally {
+					service.dispose();
+				}
+			} catch (error) {
+				return errorResult(error instanceof Error ? error.message : String(error));
+			}
+		},
+	});
+
+	registerTool({
+		name: "refactor_organize_imports",
+		label: "refactor_organize_imports",
+		description: `Organize TypeScript/JavaScript imports using the TypeScript source organize-imports action.
+
+Dry-run defaults to true and returns touched files plus a preview. Set dryRun:false to apply.`,
+		parameters: Type.Object({
+			files: Type.Optional(Type.Array(Type.String(), { description: "Files to organize" })),
+			dirs: Type.Optional(
+				Type.Array(Type.String(), { description: "Directories to scan for TS/JS files" })
+			),
+			dryRun: Type.Optional(Type.Boolean({ description: "Preview only (default: true)" })),
+			force: Type.Optional(Type.Boolean({ description: "Allow large edits on apply" })),
+		}),
+		async execute(
+			_toolCallId: string,
+			params: { dirs?: string[]; dryRun?: boolean; files?: string[]; force?: boolean },
+			_signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			ctx: ExtensionContext
+		) {
+			try {
+				const dryRun = params.dryRun ?? true;
+				const root = normalizeRoot(ctx.cwd);
+				const files = collectOrganizeImportFiles(root, params.files, params.dirs);
+				if (files.length === 0) return errorResult("No TypeScript or JavaScript files matched");
+
+				const ts = loadTypeScript(files[0] ?? root);
+				const service = createProjectService(ts, root, files[0] ?? root);
+				try {
+					const changes = files.flatMap((fileName) =>
+						service.organizeImports({ fileName, type: "file" }, {}, {})
+					);
+					const staged = stageWorkspaceEdit(root, changes);
+					return finalizeTextOnlyChange(staged, { dryRun, force: params.force ?? false });
+				} finally {
+					service.dispose();
+				}
+			} catch (error) {
+				return errorResult(error instanceof Error ? error.message : String(error));
+			}
+		},
+	});
+}
+
+/**
+ * Normalizes the project root used for path containment checks.
+ *
+ * @param cwd - Current working directory from the extension context
+ * @returns Absolute normalized root path
+ */
+function normalizeRoot(cwd: string): string {
+	return path.resolve(cwd);
+}
+
+/**
+ * Loads TypeScript from the project first, then from tallow's dependencies.
+ *
+ * @param searchStart - File or directory used for local TypeScript lookup
+ * @returns TypeScript compiler/language-service module
+ */
+function loadTypeScript(searchStart: string): TypeScriptModule {
+	if (typescriptModuleOverride instanceof Error) throw typescriptModuleOverride;
+	if (typescriptModuleOverride) return typescriptModuleOverride;
+
+	const local = findNearestTypeScriptModule(searchStart);
+	try {
+		return require(local ?? "typescript") as TypeScriptModule;
+	} catch (error) {
+		const suffix = error instanceof Error ? `: ${error.message}` : "";
+		throw new Error(`TypeScript is required for refactor tools${suffix}`);
+	}
+}
+
+/**
+ * Finds the nearest project-local TypeScript module.
+ *
+ * @param start - Directory to start searching from
+ * @returns Absolute path to typescript.js, or null when missing
+ */
+function findNearestTypeScriptModule(start: string): string | null {
+	let current =
+		fs.existsSync(start) && fs.statSync(start).isFile() ? path.dirname(start) : path.resolve(start);
+	const root = path.parse(current).root;
+	while (true) {
+		const candidate = path.join(current, "node_modules", "typescript", "lib", "typescript.js");
+		if (fs.existsSync(candidate)) return candidate;
+		if (current === root) return null;
+		current = path.dirname(current);
+	}
+}
+
+/**
+ * Creates a TypeScript language service for the nearest tsconfig/jsconfig project.
+ *
+ * @param ts - TypeScript module
+ * @param root - Project root for path validation
+ * @param anchorFile - File used to locate tsconfig.json
+ * @returns Language service instance
+ */
+function createProjectService(
+	ts: TypeScriptModule,
+	root: string,
+	anchorFile: string
+): LanguageService {
+	const config = readProjectConfig(ts, root, anchorFile);
+	const versions = new Map(config.fileNames.map((fileName) => [path.resolve(fileName), "0"]));
+	const fileNames = new Set(config.fileNames.map((fileName) => path.resolve(fileName)));
+	fileNames.add(path.resolve(anchorFile));
+
+	const host: LanguageServiceHost = {
+		directoryExists: fs.existsSync,
+		fileExists: fs.existsSync,
+		getCompilationSettings: () => config.options,
+		getCurrentDirectory: () => root,
+		getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+		getScriptFileNames: () => [...fileNames],
+		getScriptSnapshot(fileName) {
+			const text = fs.existsSync(fileName) ? fs.readFileSync(fileName, "utf-8") : undefined;
+			return text === undefined ? undefined : ts.ScriptSnapshot.fromString(text);
+		},
+		getScriptVersion: (fileName) => versions.get(path.resolve(fileName)) ?? "0",
+		readDirectory: ts.sys.readDirectory,
+		readFile: ts.sys.readFile,
+		useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+	};
+
+	return ts.createLanguageService(host);
+}
+
+/**
+ * Reads the TypeScript project config nearest to the anchor file.
+ *
+ * @param ts - TypeScript module
+ * @param root - Project root fallback
+ * @param anchorFile - File used to locate project config
+ * @returns Parsed command line
+ */
+function readProjectConfig(
+	ts: TypeScriptModule,
+	root: string,
+	anchorFile: string
+): ParsedCommandLine {
+	const configPath =
+		ts.findConfigFile(path.dirname(anchorFile), fs.existsSync, "tsconfig.json") ??
+		ts.findConfigFile(path.dirname(anchorFile), fs.existsSync, "jsconfig.json");
+	if (!configPath) {
+		return {
+			errors: [],
+			fileNames: collectFiles(root),
+			options: { allowJs: true, checkJs: false, target: ts.ScriptTarget.Latest },
+		};
+	}
+
+	const raw = ts.readConfigFile(configPath, (fileName) => fs.readFileSync(fileName, "utf-8"));
+	if (raw.error) {
+		throw new Error(ts.flattenDiagnosticMessageText(raw.error.messageText, "\n"));
+	}
+	const parsed = ts.parseJsonConfigFileContent(
+		raw.config,
+		{
+			fileExists: fs.existsSync,
+			readDirectory: ts.sys.readDirectory,
+			readFile: ts.sys.readFile,
+			useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+		},
+		path.dirname(configPath)
+	);
+	if (parsed.errors.length > 0) {
+		throw new Error(ts.flattenDiagnosticMessageText(parsed.errors[0]?.messageText, "\n"));
+	}
+	return parsed;
+}
+
+/**
+ * Collects TS/JS source files under a root for config-less projects.
+ *
+ * @param root - Project root to scan
+ * @returns Absolute source file paths
+ */
+function collectFiles(root: string): string[] {
+	const files: string[] = [];
+	const visit = (directory: string): void => {
+		for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+			const absolute = path.join(directory, entry.name);
+			if (entry.isDirectory()) {
+				if (!VENDOR_SEGMENTS.has(entry.name)) visit(absolute);
+				continue;
+			}
+			if (isTypeScriptLikeFile(absolute)) files.push(absolute);
+		}
+	};
+	visit(root);
+	return files;
+}
+
+/**
+ * Collects files requested by the organize-imports tool.
+ *
+ * @param root - Project root for path validation
+ * @param files - Optional explicit files
+ * @param dirs - Optional directories to scan
+ * @returns Absolute files to organize
+ */
+function collectOrganizeImportFiles(root: string, files?: string[], dirs?: string[]): string[] {
+	const result = new Set<string>();
+	for (const file of files ?? []) {
+		const absolute = resolveSafePath(root, file);
+		if (!isTypeScriptLikeFile(absolute)) continue;
+		result.add(absolute);
+	}
+	for (const dir of dirs ?? []) {
+		const absoluteDir = resolveSafePath(root, dir, { allowRoot: true });
+		if (!fs.existsSync(absoluteDir) || !fs.statSync(absoluteDir).isDirectory()) {
+			throw new Error(`Directory does not exist: ${dir}`);
+		}
+		for (const file of collectFiles(absoluteDir)) {
+			resolveSafePath(root, file);
+			result.add(file);
+		}
+	}
+	if (!files && !dirs) {
+		for (const file of collectFiles(root)) result.add(file);
+	}
+	return [...result].sort();
+}
+
+/**
+ * Checks whether a path is a TS/JS source file TypeScript can refactor.
+ *
+ * @param filePath - File path to inspect
+ * @returns True when the extension is supported
+ */
+function isTypeScriptLikeFile(filePath: string): boolean {
+	return [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"].includes(path.extname(filePath));
+}
+
+/**
+ * Converts 1-indexed line/character input to a zero-based absolute offset.
+ *
+ * @param text - File contents
+ * @param line - 1-indexed line number
+ * @param character - 1-indexed character number
+ * @returns Absolute text offset
+ */
+function positionFromLineCharacter(text: string, line: number, character: number): number {
+	if (!Number.isInteger(line) || line < 1) throw new Error("line must be a positive integer");
+	if (!Number.isInteger(character) || character < 1) {
+		throw new Error("character must be a positive integer");
+	}
+	let offset = 0;
+	const lines = text.split(/\n/);
+	if (line > lines.length) throw new Error("line is outside the file");
+	for (let index = 0; index < line - 1; index++) offset += (lines[index]?.length ?? 0) + 1;
+	const lineText = lines[line - 1] ?? "";
+	if (character - 1 > lineText.length) throw new Error("character is outside the line");
+	return offset + character - 1;
+}
+
+/**
+ * Validates a TypeScript identifier-ish rename target.
+ *
+ * @param newName - Proposed symbol name
+ * @returns Nothing
+ */
+function validateIdentifier(newName: string): void {
+	if (!/^[$A-Z_a-z][$\w]*$/.test(newName)) {
+		throw new Error(`Invalid TypeScript identifier: ${newName}`);
+	}
+}
+
+/**
+ * Resolves and validates a path is inside the project and outside generated/vendor dirs.
+ *
+ * @param root - Project root
+ * @param input - User-provided path
+ * @returns Absolute normalized path
+ */
+function resolveSafePath(
+	root: string,
+	input: string,
+	options: { readonly allowRoot?: boolean } = {}
+): string {
+	const absolute = path.resolve(root, input);
+	const relative = path.relative(root, absolute);
+	if (relative === "") {
+		if (options.allowRoot) return absolute;
+		throw new Error(`Refusing to touch project root as a file: ${input}`);
+	}
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		throw new Error(`Refusing to touch path outside project root: ${input}`);
+	}
+	const segments = relative.split(path.sep);
+	const blocked = segments.find((segment) => VENDOR_SEGMENTS.has(segment));
+	if (blocked) throw new Error(`Refusing to touch path under ${blocked}: ${input}`);
+	return absolute;
+}
+
+/**
+ * Stages TypeScript text changes into a deterministic workspace edit.
+ *
+ * @param root - Project root
+ * @param changes - TypeScript file text changes
+ * @returns Staged workspace edit
+ */
+export function stageWorkspaceEdit(
+	root: string,
+	changes: readonly FileTextChanges[]
+): StagedWorkspaceEdit {
+	const grouped = new Map<string, TextEdit[]>();
+	let editCount = 0;
+
+	for (const change of changes) {
+		const fileName = resolveSafePath(root, change.fileName);
+		if (!fs.existsSync(fileName) && !change.isNewFile) {
+			throw new Error(`Cannot edit missing file: ${path.relative(root, fileName)}`);
+		}
+		const existing = grouped.get(fileName) ?? [];
+		for (const textChange of change.textChanges) {
+			existing.push({
+				end: textChange.span.start + textChange.span.length,
+				newText: textChange.newText,
+				start: textChange.span.start,
+			});
+			editCount++;
+		}
+		grouped.set(fileName, existing);
+	}
+
+	const files = new Map<string, FileEditSet>();
+	for (const [fileName, edits] of [...grouped.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+		const originalText = fs.existsSync(fileName) ? fs.readFileSync(fileName, "utf-8") : "";
+		const sorted = [...edits].sort((a, b) => b.start - a.start || b.end - a.end);
+		validateEdits(originalText, sorted, fileName, root);
+		files.set(fileName, { edits: sorted, originalText });
+	}
+
+	return { editCount, files, root };
+}
+
+/**
+ * Stages a file move plus optional import-update edits.
+ *
+ * @param root - Project root
+ * @param from - Existing source path
+ * @param to - Destination path
+ * @param importEdits - TypeScript import edits
+ * @returns Staged filesystem change
+ */
+function stageFileMove(
+	root: string,
+	from: string,
+	to: string,
+	importEdits: readonly FileTextChanges[]
+): StagedFileSystemChange {
+	const stagedEdit = stageWorkspaceEdit(root, importEdits);
+	const nextContents = buildNextContents(stagedEdit);
+	const movedContent = nextContents.get(from) ?? fs.readFileSync(from, "utf-8");
+	nextContents.delete(from);
+	nextContents.set(to, movedContent);
+	return {
+		createdFiles: [to],
+		deletedFiles: [from],
+		edit: stagedEdit,
+		nextContents,
+	};
+}
+
+/**
+ * Validates edits are within bounds and do not overlap.
+ *
+ * @param text - Original file text
+ * @param reverseSortedEdits - Edits sorted descending by start offset
+ * @param fileName - File being edited
+ * @param root - Project root for messages
+ * @returns Nothing
+ */
+function validateEdits(
+	text: string,
+	reverseSortedEdits: readonly TextEdit[],
+	fileName: string,
+	root: string
+): void {
+	let previousStart = text.length + 1;
+	for (const edit of reverseSortedEdits) {
+		if (edit.start < 0 || edit.end < edit.start || edit.end > text.length) {
+			throw new Error(`Invalid edit span in ${path.relative(root, fileName)}`);
+		}
+		if (edit.end > previousStart) {
+			throw new Error(`Overlapping edits in ${path.relative(root, fileName)}`);
+		}
+		previousStart = edit.start;
+	}
+}
+
+/**
+ * Applies edits to a text string in reverse-position order.
+ *
+ * @param text - Original file text
+ * @param reverseSortedEdits - Edits sorted descending by start offset
+ * @returns Edited text
+ */
+export function applyTextEdits(text: string, reverseSortedEdits: readonly TextEdit[]): string {
+	let next = text;
+	for (const edit of reverseSortedEdits) {
+		next = `${next.slice(0, edit.start)}${edit.newText}${next.slice(edit.end)}`;
+	}
+	return next;
+}
+
+/**
+ * Computes next file contents for every edited file.
+ *
+ * @param staged - Staged text-only workspace edit
+ * @returns Map of absolute file path to new contents
+ */
+function buildNextContents(staged: StagedWorkspaceEdit): Map<string, string> {
+	const next = new Map<string, string>();
+	for (const [fileName, fileEdit] of staged.files) {
+		next.set(fileName, applyTextEdits(fileEdit.originalText, fileEdit.edits));
+	}
+	return next;
+}
+
+/**
+ * Produces and optionally applies a text-only workspace edit.
+ *
+ * @param staged - Staged edit
+ * @param options - Dry-run, force, and guard settings
+ * @returns Agent tool result
+ */
+function finalizeTextOnlyChange(
+	staged: StagedWorkspaceEdit,
+	options: { readonly dryRun: boolean; readonly force: boolean }
+): {
+	content: { text: string; type: "text" }[];
+	details: RefactorToolResultDetails;
+	isError?: boolean;
+} {
+	const nextContents = buildNextContents(staged);
+	if (!options.dryRun) {
+		guardLargeEdit(staged, options.force);
+		writeAll(nextContents, []);
+	}
+	return successResult(staged, nextContents, options.dryRun, [], []);
+}
+
+/**
+ * Produces and optionally applies a file move and import edits.
+ *
+ * @param staged - Staged file-system change
+ * @param options - Dry-run, force, and guard settings
+ * @returns Agent tool result
+ */
+function finalizeFileSystemChange(
+	staged: StagedFileSystemChange,
+	options: { readonly dryRun: boolean; readonly force: boolean }
+): {
+	content: { text: string; type: "text" }[];
+	details: RefactorToolResultDetails;
+	isError?: boolean;
+} {
+	if (!options.dryRun) {
+		guardLargeEdit(staged.edit, options.force);
+		writeAll(staged.nextContents, staged.deletedFiles);
+	}
+	return successResult(
+		staged.edit,
+		staged.nextContents,
+		options.dryRun,
+		staged.createdFiles,
+		staged.deletedFiles
+	);
+}
+
+/**
+ * Rejects large non-dry-run edits unless force is set.
+ *
+ * @param staged - Staged edit to inspect
+ * @param force - Whether the caller explicitly allows large edits
+ * @returns Nothing
+ */
+function guardLargeEdit(staged: StagedWorkspaceEdit, force: boolean): void {
+	if (force) return;
+	if (staged.files.size > LARGE_EDIT_FILE_LIMIT || staged.editCount > LARGE_EDIT_COUNT_LIMIT) {
+		throw new Error(
+			`Refactor touches ${staged.files.size} files and ${staged.editCount} edits; rerun with force:true to apply`
+		);
+	}
+}
+
+/**
+ * Writes all staged contents after validation, then removes deleted files.
+ *
+ * @param nextContents - Files and final contents to write
+ * @param deletedFiles - Files to remove after writes succeed
+ * @returns Nothing
+ */
+function writeAll(
+	nextContents: ReadonlyMap<string, string>,
+	deletedFiles: readonly string[]
+): void {
+	try {
+		for (const [fileName, content] of nextContents) {
+			fs.mkdirSync(path.dirname(fileName), { recursive: true });
+			fs.writeFileSync(fileName, content, "utf-8");
+		}
+		for (const fileName of deletedFiles) fs.rmSync(fileName, { force: true });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Refactor write failed after staging validation; filesystem may be partially updated: ${message}`
+		);
+	}
+}
+
+/**
+ * Builds a successful tool result with preview text.
+ *
+ * @param staged - Staged edit metadata
+ * @param nextContents - Next file contents
+ * @param dryRun - Whether this was preview-only
+ * @param createdFiles - Created/moved destination files
+ * @param deletedFiles - Deleted/moved source files
+ * @returns Tool result
+ */
+function successResult(
+	staged: StagedWorkspaceEdit,
+	nextContents: ReadonlyMap<string, string>,
+	dryRun: boolean,
+	createdFiles: readonly string[],
+	deletedFiles: readonly string[]
+): { content: { text: string; type: "text" }[]; details: RefactorToolResultDetails } {
+	const touched = [...new Set([...staged.files.keys(), ...createdFiles, ...deletedFiles])].sort();
+	const relative = touched.map((fileName) => path.relative(staged.root, fileName));
+	const header = [
+		`${dryRun ? "Preview" : "Applied"}: ${touched.length} file(s), ${staged.editCount} edit(s)`,
+		...relative.map((fileName) => `- ${fileName}`),
+	];
+	const diff = renderPreview(staged.root, staged.files, nextContents, createdFiles, deletedFiles);
+	return {
+		content: [{ type: "text", text: `${header.join("\n")}\n\n${diff}` }],
+		details: { dryRun, editCount: staged.editCount, touchedFiles: relative },
+	};
+}
+
+/**
+ * Builds a safe error tool result.
+ *
+ * @param message - Error message to show the agent
+ * @returns Tool error result
+ */
+function errorResult(message: string): {
+	content: { text: string; type: "text" }[];
+	details: object;
+	isError: true;
+} {
+	return { content: [{ type: "text", text: message }], details: {}, isError: true };
+}
+
+/**
+ * Renders a unified diff-like preview for changed files.
+ *
+ * @param root - Project root for relative paths
+ * @param originalFiles - Original file edit map
+ * @param nextContents - Next file contents
+ * @param createdFiles - Newly created files
+ * @param deletedFiles - Deleted files
+ * @returns Preview text
+ */
+function renderPreview(
+	root: string,
+	originalFiles: ReadonlyMap<string, FileEditSet>,
+	nextContents: ReadonlyMap<string, string>,
+	createdFiles: readonly string[],
+	deletedFiles: readonly string[]
+): string {
+	const files = [
+		...new Set([...originalFiles.keys(), ...nextContents.keys(), ...createdFiles, ...deletedFiles]),
+	].sort();
+	if (files.length === 0) return "No changes.";
+	return files
+		.map((fileName) => {
+			const relative = path.relative(root, fileName);
+			const original =
+				originalFiles.get(fileName)?.originalText ??
+				(fs.existsSync(fileName) ? fs.readFileSync(fileName, "utf-8") : "");
+			const next = deletedFiles.includes(fileName) ? "" : (nextContents.get(fileName) ?? original);
+			return renderFileDiff(relative, original, next);
+		})
+		.join("\n");
+}
+
+/**
+ * Renders a compact unified diff for one file.
+ *
+ * @param relativePath - Display path
+ * @param original - Original contents
+ * @param next - New contents
+ * @returns Diff text
+ */
+function renderFileDiff(relativePath: string, original: string, next: string): string {
+	if (original === next) return `--- ${relativePath}\n+++ ${relativePath}\n(no textual changes)\n`;
+	const oldLines = splitLines(original);
+	const newLines = splitLines(next);
+	return [`--- ${relativePath}`, `+++ ${relativePath}`, ...buildLineDiff(oldLines, newLines)].join(
+		"\n"
+	);
+}
+
+/**
+ * Splits text into stable display lines without adding phantom trailing lines.
+ *
+ * @param text - Text to split
+ * @returns Lines for diffing
+ */
+function splitLines(text: string): string[] {
+	if (text.length === 0) return [];
+	const lines = text.split("\n");
+	if (lines.at(-1) === "") lines.pop();
+	return lines;
+}
+
+/**
+ * Builds a small LCS-based line diff.
+ *
+ * @param oldLines - Original lines
+ * @param newLines - New lines
+ * @returns Diff body lines
+ */
+function buildLineDiff(oldLines: readonly string[], newLines: readonly string[]): string[] {
+	const table = Array.from({ length: oldLines.length + 1 }, () =>
+		Array<number>(newLines.length + 1).fill(0)
+	);
+	for (let i = oldLines.length - 1; i >= 0; i--) {
+		const row = table[i];
+		if (!row) continue;
+		for (let j = newLines.length - 1; j >= 0; j--) {
+			row[j] =
+				oldLines[i] === newLines[j]
+					? (table[i + 1]?.[j + 1] ?? 0) + 1
+					: Math.max(table[i + 1]?.[j] ?? 0, row[j + 1] ?? 0);
+		}
+	}
+
+	const diff: string[] = [];
+	let i = 0;
+	let j = 0;
+	while (i < oldLines.length || j < newLines.length) {
+		if (i < oldLines.length && j < newLines.length && oldLines[i] === newLines[j]) {
+			diff.push(` ${oldLines[i]}`);
+			i++;
+			j++;
+		} else if (
+			j < newLines.length &&
+			(i === oldLines.length || (table[i]?.[j + 1] ?? 0) >= (table[i + 1]?.[j] ?? 0))
+		) {
+			diff.push(`+${newLines[j]}`);
+			j++;
+		} else if (i < oldLines.length) {
+			diff.push(`-${oldLines[i]}`);
+			i++;
+		}
+	}
+	return diff;
+}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"@sinclair/typebox": "0.34.49",
 		"ai": "^6.0.162",
 		"commander": "^14.0.3",
+		"typescript": "^6.0.2",
 		"unpdf": "^1.6.0",
 		"vscode-jsonrpc": "8.2.1",
 		"vscode-languageserver-protocol": "3.17.5"
@@ -91,8 +92,7 @@
 		"@mariozechner/pi-ai": "^0.70.0",
 		"@types/node": "25.6.0",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.4.0",
-		"typescript": "^6.0.2"
+		"lint-staged": "^16.4.0"
 	},
 	"engines": {
 		"node": ">=22"

--- a/tests/e2e-profiles/standard-boot.test.ts
+++ b/tests/e2e-profiles/standard-boot.test.ts
@@ -55,6 +55,9 @@ describe("Standard Profile", () => {
 			"lsp_symbols",
 			"lsp_workspace_symbols",
 			"lsp_status",
+			"refactor_rename_symbol",
+			"refactor_move_file",
+			"refactor_organize_imports",
 		];
 
 		for (const name of expected) {


### PR DESCRIPTION
## Summary
- Adds editor-style TypeScript refactor tools for symbol rename, file move with import updates, and organize imports.
- Uses TypeScript language-service workspace edits with dry-run previews, guarded apply, path safety, overlap detection, and large-edit force protection.
- Updates LSP docs, extension metadata, standard profile expectations, and changelog entries.

## Testing
- `bun run lint`
- `bun test extensions/lsp`
- `bun run typecheck`
- `bun run typecheck:extensions`
- `bun run test:docs`
- `bun test tests/e2e-profiles/standard-boot.test.ts`
- `bun run build`