### PR TITLE
feat: add project worktree transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **worktree:** add `/worktree-create` and `worktree_create` for creating a
+  persistent branch worktree and transitioning the session into it
+
+### Fixed
+
+- **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
+  tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
+  transition compatibility hooks during the upgrade
+- **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
+  config so dependency bumps continue to build and validate cleanly
+- **git-status:** move git / GitHub status refreshes off the main thread and
+  add PR lookup backoff so slow `gh pr view` checks no longer freeze prompt
+  input while you type
+- **interactive:** stabilize settings submenu transitions so changing thinking
+  level no longer triggers chat re-append jitter or viewport jumps
+- **interactive:** reset render grace before chat rebuild paths
+  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
+  churn across reload, fork, navigation, and settings-driven rebuilds
+- **interactive:** rebind workspace transitions through the live runtime host
+  so cwd and footer git metadata update after moving sessions
+- **rewind:** prune stale snapshot refs for deleted sessions on startup so
+  internal git checkpoints stop accumulating forever
+- **runtime:** remove published runtime wrapper references to `src/`, making
+  global installs resilient when only `runtime/` and `dist/` are shipped
+- **tasks:** top-align the side-by-side background column and require a wider
+  terminal before using split layout, removing large blank gaps above
+  background task content
+
+
 ## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
 
 
@@ -25,31 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **deps:** adapt tallow to pi 0.70.0 ([ed91a84](https://github.com/dungle-scrubs/tallow/commit/ed91a843d545c94c5277e6911f4089fc0bb40584))
 * **deps:** bump pi-* dependencies ([7a813a9](https://github.com/dungle-scrubs/tallow/commit/7a813a9be6a83732263ce28139243c63aba9105b))
-
-## [Unreleased]
-
-### Fixed
-
-- **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
-  tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
-  transition compatibility hooks during the upgrade
-- **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
-  config so dependency bumps continue to build and validate cleanly
-- **git-status:** move git / GitHub status refreshes off the main thread and
-  add PR lookup backoff so slow `gh pr view` checks no longer freeze prompt
-  input while you type
-- **interactive:** stabilize settings submenu transitions so changing thinking
-  level no longer triggers chat re-append jitter or viewport jumps
-- **interactive:** reset render grace before chat rebuild paths
-  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
-  churn across reload, fork, navigation, and settings-driven rebuilds
-- **rewind:** prune stale snapshot refs for deleted sessions on startup so
-  internal git checkpoints stop accumulating forever
-- **runtime:** remove published runtime wrapper references to `src/`, making
-  global installs resilient when only `runtime/` and `dist/` are shipped
-- **tasks:** top-align the side-by-side background column and require a wider
-  terminal before using split layout, removing large blank gaps above
-  background task content
 
 ## [0.9.6](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.5...tallow-v0.9.6) (2026-04-20)
 

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **worktree:** add `/worktree-create` and `worktree_create` for creating a
+  persistent branch worktree and transitioning the session into it
+
 ### Fixed
 
 - **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
@@ -17,16 +22,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transition compatibility hooks during the upgrade
 - **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
   config so dependency bumps continue to build and validate cleanly
+- **git-status:** move git / GitHub status refreshes off the main thread and
+  add PR lookup backoff so slow `gh pr view` checks no longer freeze prompt
+  input while you type
 - **interactive:** stabilize settings submenu transitions so changing thinking
   level no longer triggers chat re-append jitter or viewport jumps
 - **interactive:** reset render grace before chat rebuild paths
   (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
   churn across reload, fork, navigation, and settings-driven rebuilds
+- **interactive:** rebind workspace transitions through the live runtime host
+  so cwd and footer git metadata update after moving sessions
+- **rewind:** prune stale snapshot refs for deleted sessions on startup so
+  internal git checkpoints stop accumulating forever
 - **runtime:** remove published runtime wrapper references to `src/`, making
   global installs resilient when only `runtime/` and `dist/` are shipped
 - **tasks:** top-align the side-by-side background column and require a wider
   terminal before using split layout, removing large blank gaps above
   background task content
+
+
+## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
+
+
+### Fixed
+
+* **interactive:** listen for the compaction events pi actually emits ([5b833da](https://github.com/dungle-scrubs/tallow/commit/5b833dabb0dbb3a0b65787f077138f189fbb6ec6))
+
+## [0.9.7](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.6...tallow-v0.9.7) (2026-04-24)
+
+
+### Fixed
+
+* **git-status:** stop blocking prompt input ([542ca47](https://github.com/dungle-scrubs/tallow/commit/542ca47af84305d82258b4fa8cd6f4211c442cd8))
+* **rewind:** prune stale snapshot refs ([6e2d816](https://github.com/dungle-scrubs/tallow/commit/6e2d81696f1625542222ef2536f2c2631f3fb48f))
+
+
+### Maintenance
+
+* **deps:** adapt tallow to pi 0.70.0 ([ed91a84](https://github.com/dungle-scrubs/tallow/commit/ed91a843d545c94c5277e6911f4089fc0bb40584))
+* **deps:** bump pi-* dependencies ([7a813a9](https://github.com/dungle-scrubs/tallow/commit/7a813a9be6a83732263ce28139243c63aba9105b))
+
+## [0.9.6](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.5...tallow-v0.9.6) (2026-04-20)
+
+
+### Fixed
+
+* **ci:** stop self-updating npm in release publish ([b698f20](https://github.com/dungle-scrubs/tallow/commit/b698f20193311d13bc396ec08f284a1700c2796a))
+* **context-fork:** ignore late fork completions after reset ([62483e4](https://github.com/dungle-scrubs/tallow/commit/62483e43d4f3f42b4779ce973cbff9b48e638f0d))
+* **deps:** override vulnerable transitive packages ([9486ee2](https://github.com/dungle-scrubs/tallow/commit/9486ee24d2f0c1153378ba567b25449de25b00da))
+* **interactive:** anchor continue startup to transcript tail ([96c73c8](https://github.com/dungle-scrubs/tallow/commit/96c73c85ba6f54c6cafe98539aff58613d21d0d8))
+* **interactive:** avoid forced redraws after normal turns ([94b5a28](https://github.com/dungle-scrubs/tallow/commit/94b5a283ed10de377806003bb17a7f9c16b461dd))
+* **interactive:** clear scrollback on session resets ([9675927](https://github.com/dungle-scrubs/tallow/commit/96759274ae70b2a3e6c920dadb4e03840609561c))
+* **interactive:** stop resume transcript replay on startup ([16c9fd0](https://github.com/dungle-scrubs/tallow/commit/16c9fd05c819b08e582018c93bf11727783d2769))
+* **reset:** complete clear and render regression hardening ([c506950](https://github.com/dungle-scrubs/tallow/commit/c506950e78d205991720881ae882afc827b84aa7))
+* **tui:** redraw only the visible viewport tail ([9bd4193](https://github.com/dungle-scrubs/tallow/commit/9bd4193f2503c10a5b851085cfa1abe86a0cc4fa))
+
+
+### Changed
+
+* **interactive:** reduce Sonar noise in startup patches ([5616a36](https://github.com/dungle-scrubs/tallow/commit/5616a36dc03f33596a35545669dc2b259c46e1b8))
+* **tui:** break TUI diff rendering into helpers ([9fbe459](https://github.com/dungle-scrubs/tallow/commit/9fbe459692cdf9c0f8656e13a46255322c624361))
+* **tui:** extract app-owned image and link helpers ([cc8baf7](https://github.com/dungle-scrubs/tallow/commit/cc8baf7bafac5a588c6c39b4068cc88442ebc92f))
+* **tui:** move editor and settings hooks out of the fork ([22feb7f](https://github.com/dungle-scrubs/tallow/commit/22feb7f813acf93a6ea9ed0f22a7b58dda36033d))
+* **tui:** move reset and render hooks out of the fork ([b6459c8](https://github.com/dungle-scrubs/tallow/commit/b6459c8cfd4825773c5469cb09af09a1b27b73e6))
+* **tui:** revert dead fork surfaces to upstream ([7c1176a](https://github.com/dungle-scrubs/tallow/commit/7c1176ae7929424284d65c6d19d9261ef89a9fdf))
+* **tui:** shrink input and selection drift ([5c6abfe](https://github.com/dungle-scrubs/tallow/commit/5c6abfe508468b92af8c2b421b925c9ed097d6cf))
+* **tui:** split editor and settings patches from pi-tui shim ([078cbc6](https://github.com/dungle-scrubs/tallow/commit/078cbc6d9bf11f5b5a46515459e57ebf241509ff))
+
+
+### Documentation
+
+* **changelog:** keep unreleased at the top ([d77caac](https://github.com/dungle-scrubs/tallow/commit/d77caac1ee42818b4f5a98a9f871f6bccdc595aa))
+* **plan:** add clear reset regression plan ([72dc402](https://github.com/dungle-scrubs/tallow/commit/72dc402078701571cc265bedd0a977636a556ee6))
+* **tui:** audit and document pi-tui fork drift ([5fc8515](https://github.com/dungle-scrubs/tallow/commit/5fc8515e0f6248ab89dbd3aee8cd37666e0b194e))
+
+
+### Maintenance
+
+* **clear:** prove reset cancels compact continuation ([ec4bb3e](https://github.com/dungle-scrubs/tallow/commit/ec4bb3ef6bece5f87942d1aff237057561f140d3))
+* **git:** ignore local package bundles ([0015ead](https://github.com/dungle-scrubs/tallow/commit/0015ead124ab164c0ea11b4ffd79a4c1c895dd97))
+* **sonar:** refresh baseline on main pushes ([57281db](https://github.com/dungle-scrubs/tallow/commit/57281dbef977e5032c59351b21459ec653a4ac3e))
+* **tui:** move settings-list transition coverage to core patches ([d0f1f9d](https://github.com/dungle-scrubs/tallow/commit/d0f1f9d90c259d86cc17f0825a6597c296c399b1))
+- **interactive:** reset render grace before chat rebuild paths
 
 ## [0.9.5](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.4...tallow-v0.9.5) (2026-04-16)
 

--- a/docs/src/content/docs/extensions/hooks.mdx
+++ b/docs/src/content/docs/extensions/hooks.mdx
@@ -83,7 +83,8 @@ Claude-compatible aliases are also supported in translated `.claude` hooks:
 - `WorktreeRemove` → `worktree_remove`
 
 Worktree payloads include `worktreePath`, `repoRoot`, `scope`, `timestamp`,
-and optional `agentId` for subagent-scoped events.
+and optional `agentId` for subagent-scoped events. Scope values are `project`,
+`session`, and `subagent`.
 
 ### Session lifecycle
 

--- a/docs/src/content/docs/extensions/worktree.mdx
+++ b/docs/src/content/docs/extensions/worktree.mdx
@@ -1,14 +1,17 @@
 ---
 title: worktree
-description: Detached git worktree isolation for sessions and subagents.
+description: Git worktree isolation and branch worktree transitions.
 ---
 
 The `worktree` extension manages temporary detached git worktrees for
-isolated execution. It is the lifecycle owner for create/remove/prune behavior.
+isolated execution and persistent branch worktrees for feature work. It is the
+lifecycle owner for create/remove/prune behavior.
 
 ## What it does
 
 - creates detached worktrees with `git worktree add --detach`
+- creates persistent branch worktrees with `/worktree-create` or the
+  `worktree_create` tool
 - removes worktrees with a git-first strategy, then filesystem fallback
 - prunes stale managed worktrees on startup
 - emits lifecycle events for hook automation
@@ -24,6 +27,23 @@ session inside a temporary detached worktree and sets:
 
 The extension reads those values, emits lifecycle events, and performs
 best-effort cleanup on `session_shutdown`.
+
+## Branch worktrees (`/worktree-create` / `worktree_create`)
+
+Use `/worktree-create <branch> [path]` to create a persistent worktree for a
+local branch and move the interactive session into it. If the branch does not
+exist, tallow creates it from `HEAD`. If the branch already exists, tallow
+checks it out in the new worktree.
+
+When no path is provided, tallow uses:
+
+```text
+~/dev/<project>_worktrees/<branch-slug>
+```
+
+The `worktree_create` tool exposes the same flow to the model with required
+`branch` and optional `baseRef` / `path` parameters. The tool should be called
+alone because the session transitions into the new worktree after creation.
 
 ## Subagent isolation (`isolation: "worktree"`)
 
@@ -62,4 +82,5 @@ Payload shape:
 }
 ```
 
-`scope` is `session` or `subagent`. `agentId` is present for subagent-scoped events.
+`scope` is `project`, `session`, or `subagent`. `agentId` is present for
+subagent-scoped events.

--- a/extensions/_shared/interop-events.ts
+++ b/extensions/_shared/interop-events.ts
@@ -50,13 +50,13 @@ export type WorktreeLifecycleEventName =
 	(typeof WORKTREE_LIFECYCLE_EVENT_NAMES)[keyof typeof WORKTREE_LIFECYCLE_EVENT_NAMES];
 
 /** Valid worktree scopes in lifecycle payloads. */
-export type WorktreeLifecycleScope = "session" | "subagent";
+export type WorktreeLifecycleScope = "project" | "session" | "subagent";
 
 /** TypeBox schema for worktree lifecycle payloads shared across extensions. */
 export const WorktreeLifecyclePayloadSchema = Type.Object({
 	agentId: Type.Optional(Type.String()),
 	repoRoot: Type.String(),
-	scope: Type.Union([Type.Literal("session"), Type.Literal("subagent")]),
+	scope: Type.Union([Type.Literal("project"), Type.Literal("session"), Type.Literal("subagent")]),
 	timestamp: Type.Number(),
 	worktreePath: Type.String(),
 });

--- a/extensions/custom-footer/index.ts
+++ b/extensions/custom-footer/index.ts
@@ -366,7 +366,10 @@ export default function customFooterExtension(pi: ExtensionAPI): void {
 				},
 
 				dispose: (() => {
-					disposeHandler = footerData.onBranchChange(() => tui.requestRender());
+					disposeHandler = footerData.onBranchChange(() => {
+						invalidateGitCache();
+						tui.requestRender();
+					});
 					return disposeHandler;
 				})(),
 			};

--- a/extensions/worktree/__tests__/lifecycle.test.ts
+++ b/extensions/worktree/__tests__/lifecycle.test.ts
@@ -13,8 +13,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	cleanupStaleWorktrees,
+	createProjectWorktree,
 	createWorktree,
 	removeWorktree,
+	resolveProjectWorktreeDefaultPath,
 	TALLOW_WORKTREE_MARKER_FILE,
 	validateGitRepo,
 } from "../lifecycle.js";
@@ -69,6 +71,42 @@ describe("worktree lifecycle", () => {
 		const markerPath = join(created.worktreePath, TALLOW_WORKTREE_MARKER_FILE);
 		expect(existsSync(markerPath)).toBe(true);
 		removeWorktree(created.worktreePath);
+	});
+
+	it("creates a persistent project worktree on a new branch", () => {
+		const worktreePath = join(tmpdir(), `tallow-project-worktree-${Date.now()}`);
+		const created = createProjectWorktree(repoRoot, {
+			branch: "feature/test-worktree",
+			path: worktreePath,
+		});
+
+		try {
+			expect(existsSync(created.worktreePath)).toBe(true);
+			expect(created.branch).toBe("feature/test-worktree");
+			expect(created.branchExisted).toBe(false);
+			expect(git(created.worktreePath, "branch", "--show-current")).toBe("feature/test-worktree");
+			expect(resolveProjectWorktreeDefaultPath(repoRoot, created.branch)).toContain(
+				"tallow-worktree-test-"
+			);
+		} finally {
+			removeWorktree(created.worktreePath);
+		}
+	});
+
+	it("checks out an existing branch in a persistent project worktree", () => {
+		git(repoRoot, "branch", "feature/existing");
+		const worktreePath = join(tmpdir(), `tallow-project-existing-${Date.now()}`);
+		const created = createProjectWorktree(repoRoot, {
+			branch: "feature/existing",
+			path: worktreePath,
+		});
+
+		try {
+			expect(created.branchExisted).toBe(true);
+			expect(git(created.worktreePath, "branch", "--show-current")).toBe("feature/existing");
+		} finally {
+			removeWorktree(created.worktreePath);
+		}
 	});
 
 	it("fails validation outside git repositories", () => {

--- a/extensions/worktree/extension.json
+++ b/extensions/worktree/extension.json
@@ -1,8 +1,8 @@
 {
 	"name": "worktree",
 	"version": "0.1.0",
-	"description": "Managed git worktree isolation lifecycle for sessions and subagents.",
-	"whenToUse": "Use when tallow should run in temporary detached git worktrees with reliable cleanup and lifecycle hooks.",
+	"description": "Managed git worktree lifecycle for session isolation, subagents, and branch worktree transitions.",
+	"whenToUse": "Use when tallow should run in git worktrees, create persistent branch worktrees, or emit worktree lifecycle hooks.",
 	"capabilities": {
 		"events": ["before_agent_start", "session_shutdown", "session_start"]
 	},

--- a/extensions/worktree/index.ts
+++ b/extensions/worktree/index.ts
@@ -1,9 +1,20 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { getWorkspaceTransitionHost } from "../../runtime/workspace-transition.js";
 import {
 	emitWorktreeLifecycleEvent,
 	type WorktreeLifecycleEventPayload,
 } from "../_shared/interop-events.js";
-import { cleanupStaleWorktrees, removeWorktree, validateGitRepo } from "./lifecycle.js";
+import {
+	cleanupStaleWorktrees,
+	createProjectWorktree,
+	removeWorktree,
+	validateGitRepo,
+} from "./lifecycle.js";
 
 /** Env var containing active session worktree path (set by CLI when -w/--worktree is used). */
 const TALLOW_WORKTREE_PATH_ENV = "TALLOW_WORKTREE_PATH";
@@ -21,6 +32,111 @@ interface SessionWorktreeState {
 	readonly worktreePath: string;
 }
 
+/** Parameters accepted by the worktree_create tool. */
+interface WorktreeCreateParams {
+	readonly baseRef?: string;
+	readonly branch: string;
+	readonly path?: string;
+}
+
+/** Details returned by worktree_create. */
+interface WorktreeCreateDetails {
+	readonly baseRef?: string;
+	readonly branch?: string;
+	readonly branchExisted?: boolean;
+	readonly reason?: string;
+	readonly repoRoot?: string;
+	readonly status: "cancelled" | "completed" | "create_failed" | "unavailable";
+	readonly worktreePath?: string;
+}
+
+/**
+ * Parse `/worktree-create` arguments.
+ *
+ * @param args - Raw slash-command argument string
+ * @returns Worktree creation parameters
+ * @throws {Error} When the branch argument is missing
+ */
+function parseWorktreeCreateArgs(args: string): WorktreeCreateParams {
+	const parts = args.trim().split(/\s+/).filter(Boolean);
+	const branch = parts[0];
+	if (!branch) {
+		throw new Error("Usage: /worktree-create <branch> [path]");
+	}
+	return {
+		branch,
+		path: parts[1],
+	};
+}
+
+/**
+ * Create a project worktree and transition the interactive session into it.
+ *
+ * @param params - Branch, base ref, and optional path
+ * @param ctx - Extension context carrying cwd and UI surface
+ * @param initiator - Whether the request came from a command or tool
+ * @returns Worktree creation and transition result details
+ */
+async function createAndEnterProjectWorktree(
+	params: WorktreeCreateParams,
+	ctx: Pick<ExtensionContext, "cwd" | "ui">,
+	initiator: "command" | "tool",
+	events: ExtensionAPI["events"]
+): Promise<WorktreeCreateDetails> {
+	const host = getWorkspaceTransitionHost();
+	if (!host) {
+		return {
+			reason: "Workspace transitions are only available in the interactive TUI session right now.",
+			status: "unavailable",
+		};
+	}
+
+	let created: ReturnType<typeof createProjectWorktree>;
+	try {
+		created = createProjectWorktree(ctx.cwd, params);
+	} catch (error) {
+		return {
+			reason: error instanceof Error ? error.message : String(error),
+			status: "create_failed",
+		};
+	}
+
+	emitWorktreeLifecycleEvent(events, "worktree_create", {
+		agentId: undefined,
+		repoRoot: created.repoRoot,
+		scope: "project",
+		timestamp: Date.now(),
+		worktreePath: created.worktreePath,
+	});
+
+	const transition = await host.requestTransition({
+		initiator,
+		sourceCwd: ctx.cwd,
+		targetCwd: created.worktreePath,
+		ui: ctx.ui,
+	});
+	if (transition.status !== "completed") {
+		return {
+			baseRef: created.baseRef,
+			branch: created.branch,
+			branchExisted: created.branchExisted,
+			reason: transition.status === "unavailable" ? transition.reason : undefined,
+			repoRoot: created.repoRoot,
+			status: transition.status,
+			worktreePath: created.worktreePath,
+		};
+	}
+
+	return {
+		baseRef: created.baseRef,
+		branch: created.branch,
+		branchExisted: created.branchExisted,
+		repoRoot: created.repoRoot,
+		status: "completed",
+		worktreePath: created.worktreePath,
+	};
+}
+
 /**
  * Worktree lifecycle extension.
  *
@@ -35,6 +151,69 @@ interface SessionWorktreeState {
 export default function worktreeExtension(pi: ExtensionAPI): void {
 	let sessionState: SessionWorktreeState | undefined;
 	let cleanedUp = false;
+
+	pi.registerCommand("worktree-create", {
+		description: "Create a persistent git worktree for a branch and enter it",
+		async handler(args: string, ctx: ExtensionCommandContext): Promise<void> {
+			let params: WorktreeCreateParams;
+			try {
+				params = parseWorktreeCreateArgs(args);
+			} catch (error) {
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+				return;
+			}
+
+			const result = await createAndEnterProjectWorktree(params, ctx, "command", pi.events);
+			if (result.status === "completed") {
+				ctx.ui.notify(`Created worktree for ${result.branch}: ${result.worktreePath}`, "info");
+				return;
+			}
+			ctx.ui.notify(result.reason ?? `Worktree creation ${result.status}.`, "error");
+		},
+	});
+
+	pi.registerTool({
+		name: "worktree_create",
+		label: "worktree_create",
+		description:
+			"Create a persistent git worktree for a branch, then transition the interactive Tallow session into it. Use when the user asks to create a new worktree/branch and continue working there.",
+		promptGuidelines: [
+			"This tool triggers an interactive workspace transition. Call it as the only tool in the response; sibling tool calls may be discarded when the session moves.",
+		],
+		parameters: Type.Object({
+			baseRef: Type.Optional(
+				Type.String({
+					description:
+						"Git ref to create the branch from when it does not already exist. Defaults to HEAD.",
+				})
+			),
+			branch: Type.String({
+				description: "Local branch name to create or check out in the new worktree.",
+			}),
+			path: Type.Optional(
+				Type.String({
+					description:
+						"Optional absolute or cwd-relative target worktree path. Defaults to ~/dev/<project>_worktrees/<branch-slug>.",
+				})
+			),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const result = await createAndEnterProjectWorktree(params, ctx, "tool", pi.events);
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text:
+							result.status === "completed"
+								? `Created worktree for ${result.branch}: ${result.worktreePath}`
+								: (result.reason ?? `Worktree creation ${result.status}.`),
+					},
+				],
+				details: result,
+				isError: result.status !== "completed",
+			};
+		},
+	});
 
 	/**
 	 * Best-effort session-worktree cleanup routine.

--- a/extensions/worktree/lifecycle.ts
+++ b/extensions/worktree/lifecycle.ts
@@ -1,8 +1,16 @@
 import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 
 /** Managed worktree directory-name prefix in the system temp dir. */
 export const TALLOW_WORKTREE_PREFIX = "tallow-worktree-";
@@ -24,12 +32,28 @@ export interface CreateWorktreeOptions {
 	readonly timestampMs?: number;
 }
 
+/** Options for creating a project branch worktree. */
+export interface CreateProjectWorktreeOptions {
+	readonly baseRef?: string;
+	readonly branch: string;
+	readonly path?: string;
+}
+
 /** Result from createWorktree. */
 export interface CreatedWorktree {
 	readonly id: string;
 	readonly repoRoot: string;
 	readonly scope: WorktreeScope;
 	readonly timestampMs: number;
+	readonly worktreePath: string;
+}
+
+/** Result from creating a persistent project branch worktree. */
+export interface CreatedProjectWorktree {
+	readonly baseRef: string;
+	readonly branch: string;
+	readonly branchExisted: boolean;
+	readonly repoRoot: string;
 	readonly worktreePath: string;
 }
 
@@ -110,6 +134,62 @@ export function createWorktree(
 		timestampMs,
 		worktreePath,
 	};
+}
+
+/**
+ * Create a persistent project worktree for a branch.
+ *
+ * Existing branches are checked out directly. Missing branches are created from
+ * the supplied base ref. The worktree is intentionally not marked for automatic
+ * cleanup because it represents user-owned project state.
+ *
+ * @param cwd - Current working directory inside the repository
+ * @param options - Branch, base ref, and optional target path
+ * @returns Created project worktree metadata
+ * @throws {Error} When git rejects the branch, path, or worktree creation
+ */
+export function createProjectWorktree(
+	cwd: string,
+	options: CreateProjectWorktreeOptions
+): CreatedProjectWorktree {
+	const repoRoot = validateGitRepo(cwd).repoRoot;
+	const branch = validateBranchName(options.branch, repoRoot);
+	const baseRef = options.baseRef?.trim() || "HEAD";
+	const branchExisted = branchExists(repoRoot, branch);
+	const worktreePath = options.path
+		? resolve(cwd, options.path)
+		: resolveProjectWorktreeDefaultPath(repoRoot, branch);
+
+	if (existsSync(worktreePath)) {
+		throw new Error(`Worktree path already exists: ${worktreePath}`);
+	}
+
+	mkdirSync(dirname(worktreePath), { recursive: true });
+	const args = branchExisted
+		? ["-C", repoRoot, "worktree", "add", worktreePath, branch]
+		: ["-C", repoRoot, "worktree", "add", "-b", branch, worktreePath, baseRef];
+	runGit(args, repoRoot);
+
+	return {
+		baseRef,
+		branch,
+		branchExisted,
+		repoRoot,
+		worktreePath,
+	};
+}
+
+/**
+ * Resolve the default persistent worktree path for a repository branch.
+ *
+ * @param repoRoot - Git repository root
+ * @param branch - Branch name
+ * @returns Default worktree path under ~/dev/<project>_worktrees/<branch-slug>
+ */
+export function resolveProjectWorktreeDefaultPath(repoRoot: string, branch: string): string {
+	const primaryRoot = resolvePrimaryWorktreeRoot(repoRoot);
+	const projectName = basename(primaryRoot);
+	return join(homedir(), "dev", `${projectName}_worktrees`, sanitizeSegment(branch));
 }
 
 /**
@@ -348,6 +428,59 @@ function sanitizeSegment(value: string): string {
 		.replace(/^-+|-+$/g, "");
 	if (!normalized) return "task";
 	return normalized.slice(0, 48);
+}
+
+/**
+ * Validate a git branch name using git's own ref parser.
+ *
+ * @param branch - Candidate branch name
+ * @param repoRoot - Repository root used for the validation command
+ * @returns Trimmed branch name
+ * @throws {Error} When the branch name is invalid
+ */
+function validateBranchName(branch: string, repoRoot: string): string {
+	const trimmed = branch.trim();
+	if (!trimmed) {
+		throw new Error("Branch name is required.");
+	}
+	runGit(["-C", repoRoot, "check-ref-format", "--branch", trimmed], repoRoot);
+	return trimmed;
+}
+
+/**
+ * Return whether a local branch already exists.
+ *
+ * @param repoRoot - Git repository root
+ * @param branch - Local branch name
+ * @returns True when refs/heads/<branch> exists
+ */
+function branchExists(repoRoot: string, branch: string): boolean {
+	try {
+		runGit(["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`], repoRoot);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Resolve the primary worktree root for naming persistent worktree groups.
+ *
+ * @param repoRoot - Current repository root, possibly itself a linked worktree
+ * @returns First path from `git worktree list`, falling back to repoRoot
+ */
+function resolvePrimaryWorktreeRoot(repoRoot: string): string {
+	try {
+		const output = runGit(["-C", repoRoot, "worktree", "list", "--porcelain"], repoRoot);
+		const firstWorktree = output
+			.split("\n")
+			.find((line) => line.startsWith("worktree "))
+			?.slice("worktree ".length)
+			.trim();
+		return firstWorktree ? resolve(firstWorktree) : repoRoot;
+	} catch {
+		return repoRoot;
+	}
 }
 
 /**

--- a/src/__tests__/workspace-transition-interactive.test.ts
+++ b/src/__tests__/workspace-transition-interactive.test.ts
@@ -52,8 +52,10 @@ interface FakeMode {
 	loadingAnimation?: { stop: () => void };
 	pendingMessagesContainer: { clear: () => void };
 	pendingTools: Map<string, unknown>;
+	rebindCurrentSession: () => Promise<void>;
 	renderInitialMessages: () => void;
 	resetExtensionUI: () => void;
+	runtimeHost: { apply: (result: { session: unknown }) => void };
 	session: FakeSession;
 	showStatus: (message: string) => void;
 	statusContainer: { clear: () => void };
@@ -145,7 +147,7 @@ function fakeAssistantEntry(text: string, id = "a1"): FakeSessionEntry {
  * @returns Fake mode object compatible with the transition host
  */
 function createFakeMode(session: FakeSession, events: string[]): FakeMode {
-	return {
+	const mode = {
 		chatContainer: {
 			clear: (): void => {
 				events.push("chat.clear");
@@ -166,11 +168,20 @@ function createFakeMode(session: FakeSession, events: string[]): FakeMode {
 			},
 		},
 		pendingTools: new Map([["tool", {}]]),
+		rebindCurrentSession: async (): Promise<void> => {
+			events.push("mode.rebindCurrentSession");
+		},
 		renderInitialMessages: (): void => {
 			events.push("mode.renderInitialMessages");
 		},
 		resetExtensionUI: (): void => {
 			events.push("mode.resetExtensionUI");
+		},
+		runtimeHost: {
+			apply: (result: { session: unknown }): void => {
+				mode.session = result.session as FakeSession;
+				events.push("runtime.apply");
+			},
 		},
 		session,
 		showStatus: (message: string): void => {
@@ -198,6 +209,7 @@ function createFakeMode(session: FakeSession, events: string[]): FakeMode {
 			events.push("mode.updateTerminalTitle");
 		},
 	};
+	return mode;
 }
 
 /**
@@ -265,6 +277,11 @@ function createDeps(
 					extensions: {} as never,
 					modelFallbackMessage: undefined,
 					resolvedPlugins: [],
+					runtime: {
+						diagnostics: [],
+						modelFallbackMessage: undefined,
+						services: { cwd: String(options.cwd) },
+					},
 					session: nextSession as never,
 					sessionId: "next-session",
 					version: "test",
@@ -375,10 +392,9 @@ describe("createInteractiveWorkspaceTransitionHost", () => {
 			"chat.clear",
 			"mode.resetExtensionUI",
 			"mode.unsubscribe",
-			"mode.initExtensions",
+			"runtime.apply",
+			"mode.rebindCurrentSession",
 			"mode.renderInitialMessages",
-			"mode.subscribeToAgent",
-			"mode.updateTerminalTitle",
 			"ui.requestRender:force",
 			"ui.working:clear",
 		]);
@@ -529,6 +545,7 @@ describe("createInteractiveWorkspaceTransitionHost", () => {
 					extensionOverrides: [];
 					extensions: never;
 					resolvedPlugins: [];
+					runtime: never;
 					session: never;
 					sessionId: string;
 					version: string;
@@ -538,6 +555,7 @@ describe("createInteractiveWorkspaceTransitionHost", () => {
 			extensionOverrides: [];
 			extensions: never;
 			resolvedPlugins: [];
+			runtime: never;
 			session: never;
 			sessionId: string;
 			version: string;
@@ -570,6 +588,11 @@ describe("createInteractiveWorkspaceTransitionHost", () => {
 			extensionOverrides: [],
 			extensions: {} as never,
 			resolvedPlugins: [],
+			runtime: {
+				diagnostics: [],
+				modelFallbackMessage: undefined,
+				services: { cwd: "/repo/b" },
+			} as never,
 			session: nextSession as never,
 			sessionId: "late",
 			version: "test",

--- a/src/workspace-transition-interactive.ts
+++ b/src/workspace-transition-interactive.ts
@@ -21,8 +21,17 @@ interface InteractiveModeLike {
 	loadingAnimation?: { stop(): void };
 	pendingMessagesContainer: { clear(): void };
 	pendingTools: Map<string, unknown>;
+	rebindCurrentSession?(): Promise<void>;
 	renderInitialMessages(): void;
 	resetExtensionUI(): void;
+	runtimeHost?: {
+		apply(result: {
+			diagnostics: unknown;
+			modelFallbackMessage: unknown;
+			services: unknown;
+			session: unknown;
+		}): void;
+	};
 	session: AgentSessionLike;
 	showStatus(message: string): void;
 	statusContainer: { clear(): void };
@@ -36,7 +45,7 @@ interface InteractiveModeLike {
 	};
 	unsubscribe?: (() => void) | undefined;
 	updateTerminalTitle(): void;
-	initExtensions(): Promise<void>;
+	initExtensions?(): Promise<void>;
 }
 
 /** Runtime shape needed from AgentSession for transition orchestration. */
@@ -226,12 +235,25 @@ async function swapInteractiveModeSession(
 	setCleanupSession: (session: TallowSession["session"]) => void
 ): Promise<void> {
 	resetInteractiveModeState(mode);
-	mode.session = next.session as AgentSessionLike;
+	if (mode.runtimeHost) {
+		mode.runtimeHost.apply({
+			diagnostics: next.runtime.diagnostics,
+			modelFallbackMessage: next.runtime.modelFallbackMessage,
+			services: next.runtime.services,
+			session: next.session,
+		});
+	} else {
+		(mode as { session: AgentSessionLike }).session = next.session as AgentSessionLike;
+	}
 	setCleanupSession(next.session);
-	await mode.initExtensions();
+	if (mode.rebindCurrentSession) {
+		await mode.rebindCurrentSession();
+	} else {
+		await mode.initExtensions?.();
+		mode.subscribeToAgent();
+		mode.updateTerminalTitle();
+	}
 	mode.renderInitialMessages();
-	mode.subscribeToAgent();
-	mode.updateTerminalTitle();
 	mode.ui.requestRender(true);
 }
 


### PR DESCRIPTION
## Summary
- Add persistent branch worktree creation via `/worktree-create` and `worktree_create`
- Rebind interactive runtime state after workspace transitions so cwd/footer git metadata update correctly
- Document branch worktree transitions and lifecycle scope values

## Testing
- `bun test extensions/worktree src/__tests__/workspace-transition-interactive.test.ts`
- `bun run typecheck`
- `bun run typecheck:extensions`
- `bun run test:docs`