### PR TITLE
Fix WebSocket 1009 diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **worktree:** add `/worktree-create` and `worktree_create` for creating a
+  persistent branch worktree and transitioning the session into it
+
+### Fixed
+
+- **codex:** add WebSocket payload diagnostics and preflight SSE fallback for
+  oversized requests that would otherwise fail with close code 1009
+- **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
+  tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
+  transition compatibility hooks during the upgrade
+- **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
+  config so dependency bumps continue to build and validate cleanly
+- **git-status:** move git / GitHub status refreshes off the main thread and
+  add PR lookup backoff so slow `gh pr view` checks no longer freeze prompt
+  input while you type
+- **interactive:** stabilize settings submenu transitions so changing thinking
+  level no longer triggers chat re-append jitter or viewport jumps
+- **interactive:** reset render grace before chat rebuild paths
+  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
+  churn across reload, fork, navigation, and settings-driven rebuilds
+- **interactive:** rebind workspace transitions through the live runtime host
+  so cwd and footer git metadata update after moving sessions
+- **rewind:** prune stale snapshot refs for deleted sessions on startup so
+  internal git checkpoints stop accumulating forever
+- **runtime:** remove published runtime wrapper references to `src/`, making
+  global installs resilient when only `runtime/` and `dist/` are shipped
+- **tasks:** top-align the side-by-side background column and require a wider
+  terminal before using split layout, removing large blank gaps above
+  background task content
+
 ## [0.9.10](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.9...tallow-v0.9.10) (2026-05-06)
 
 
@@ -29,39 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 * **worktree:** document branch worktree transitions ([16c6d87](https://github.com/dungle-scrubs/tallow/commit/16c6d876d436d038d09d44cf77228a86ed264f61))
-
-## [Unreleased]
-
-### Added
-
-- **worktree:** add `/worktree-create` and `worktree_create` for creating a
-  persistent branch worktree and transitioning the session into it
-
-### Fixed
-
-- **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
-  tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
-  transition compatibility hooks during the upgrade
-- **docs:** migrate the docs site to Astro 6 / Starlight loader-based content
-  config so dependency bumps continue to build and validate cleanly
-- **git-status:** move git / GitHub status refreshes off the main thread and
-  add PR lookup backoff so slow `gh pr view` checks no longer freeze prompt
-  input while you type
-- **interactive:** stabilize settings submenu transitions so changing thinking
-  level no longer triggers chat re-append jitter or viewport jumps
-- **interactive:** reset render grace before chat rebuild paths
-  (`renderInitialMessages()` / `rebuildChatFromMessages()`), reducing redraw
-  churn across reload, fork, navigation, and settings-driven rebuilds
-- **interactive:** rebind workspace transitions through the live runtime host
-  so cwd and footer git metadata update after moving sessions
-- **rewind:** prune stale snapshot refs for deleted sessions on startup so
-  internal git checkpoints stop accumulating forever
-- **runtime:** remove published runtime wrapper references to `src/`, making
-  global installs resilient when only `runtime/` and `dist/` are shipped
-- **tasks:** top-align the side-by-side background column and require a wider
-  terminal before using split layout, removing large blank gaps above
-  background task content
-
 
 ## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
 

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **codex:** add WebSocket payload diagnostics and preflight SSE fallback for
+  oversized requests that would otherwise fail with close code 1009
 - **deps:** restore compatibility with `@mariozechner/pi-*` 0.67 by moving
   tallow startup/CLI flows onto `AgentSessionRuntime` and preserving session
   transition compatibility hooks during the upgrade
@@ -40,6 +42,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   terminal before using split layout, removing large blank gaps above
   background task content
 
+## [0.9.10](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.9...tallow-v0.9.10) (2026-05-06)
+
+
+### Maintenance
+
+* **deps:** bump pi-* dependencies ([c2085ea](https://github.com/dungle-scrubs/tallow/commit/c2085ea35a9177726a9f47475db5b2aea061fb49))
+
+## [0.9.9](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.8...tallow-v0.9.9) (2026-05-06)
+
+
+### Added
+
+* **slash-command-bridge:** support callable prompt commands ([820520d](https://github.com/dungle-scrubs/tallow/commit/820520d0a7fa07f080b1e17a6e2cce8ef2c61fb1))
+* **worktree:** add persistent branch worktrees ([33507bb](https://github.com/dungle-scrubs/tallow/commit/33507bb086de64b6464f322b6d9011269bf61d9f))
+
+
+### Fixed
+
+* **interactive:** rebind runtime after workspace transitions ([6101aa0](https://github.com/dungle-scrubs/tallow/commit/6101aa0ac7a7e214f1ab5be5bc6ce99d3f872907))
+
+
+### Documentation
+
+* **worktree:** document branch worktree transitions ([16c6d87](https://github.com/dungle-scrubs/tallow/commit/16c6d876d436d038d09d44cf77228a86ed264f61))
 
 ## [0.9.8](https://github.com/dungle-scrubs/tallow/compare/tallow-v0.9.7...tallow-v0.9.8) (2026-04-25)
 

--- a/extensions/debug/index.ts
+++ b/extensions/debug/index.ts
@@ -621,11 +621,54 @@ export default function (pi: ExtensionAPI) {
 		});
 	}
 
+	/**
+	 * Whether the session can launch a separate WezTerm pane for live logs.
+	 *
+	 * @returns True when the wezterm_pane capability is registered
+	 */
+	function hasWeztermPaneCapability(): boolean {
+		return pi.getAllTools().some((tool) => tool.name === "wezterm_pane");
+	}
+
+	/**
+	 * Launch a live debug log tail in a new WezTerm pane.
+	 *
+	 * @param logPath - Log file to follow
+	 * @returns True when the pane launch command exits successfully
+	 */
+	async function launchLiveTailPane(logPath: string): Promise<boolean> {
+		const result = await pi.exec("wezterm", [
+			"cli",
+			"split-pane",
+			"--right",
+			"tail",
+			"-f",
+			logPath,
+		]);
+		const exitCode = "exitCode" in result ? result.exitCode : (result as { code?: number }).code;
+		return exitCode === 0;
+	}
+
 	pi.registerCommand("diagnostics", {
 		description: "Show local diagnostics tail",
-		handler: async (args: string, _ctx: ExtensionCommandContext) => {
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			const lineCount = parseTailCount(args);
-			sendLocalTailOutput(lineCount);
+			if (!ctx.hasUI || !hasWeztermPaneCapability()) {
+				sendLocalTailOutput(lineCount);
+				return;
+			}
+
+			const choice = await ctx.ui.select("Diagnostics", ["Show local tail", "Live follow in pane"]);
+			if (choice !== "Live follow in pane") {
+				sendLocalTailOutput(lineCount);
+				return;
+			}
+
+			const launched = await launchLiveTailPane(getLogPath());
+			if (!launched) {
+				ctx.ui.notify("Failed to launch diagnostics pane. Showing local tail instead.", "warning");
+				sendLocalTailOutput(lineCount);
+			}
 		},
 	});
 

--- a/extensions/hooks/__tests__/subprocess-hardening.test.ts
+++ b/extensions/hooks/__tests__/subprocess-hardening.test.ts
@@ -56,6 +56,21 @@ describe("hook subprocess hardening", () => {
 		expect(result.reason).toBeUndefined();
 	});
 
+	test("oversized hook events are sent on stdin without overflowing env", async () => {
+		const handler = createCommandHandler(
+			`node -e "let input=''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => process.stdout.write(JSON.stringify({ok:true, additionalContext: String(JSON.parse(input).payload.length) + ':' + process.env.PI_HOOK_EVENT_TRUNCATED + ':' + (process.env.PI_HOOK_EVENT || '').length})))"`,
+			2
+		);
+		const result = await runCommandHook(
+			handler,
+			{ payload: "x".repeat(128 * 1024) },
+			process.cwd()
+		);
+
+		expect(result.ok).toBe(true);
+		expect(result.additionalContext).toBe("131072:true:0");
+	});
+
 	test("large stdout is truncated to bounded output", async () => {
 		process.env[HOOK_OUTPUT_MAX_BUFFER_BYTES_ENV] = "256";
 		const handler = createCommandHandler("node -e \"process.stdout.write('x'.repeat(8192))\"", 2);

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -105,6 +105,9 @@ const HOOK_OUTPUT_MAX_BUFFER_BYTES_ENV = "TALLOW_HOOK_MAX_BUFFER_BYTES";
 /** Optional env override for hook subprocess SIGTERM→SIGKILL grace window. */
 const HOOK_FORCE_KILL_GRACE_MS_ENV = "TALLOW_HOOK_FORCE_KILL_GRACE_MS";
 
+/** Maximum hook event size copied into the subprocess environment. */
+const MAX_HOOK_EVENT_ENV_BYTES = 64 * 1024;
+
 /** Marker appended once when subprocess output is truncated due to buffer cap. */
 export const HOOK_OUTPUT_TRUNCATION_MARKER = "\n[output truncated]\n";
 
@@ -158,6 +161,22 @@ function getHookOutputMaxBufferBytes(): number {
  */
 function getHookForceKillGraceMs(): number {
 	return getPositiveIntEnv(HOOK_FORCE_KILL_GRACE_MS_ENV, DEFAULT_HOOK_FORCE_KILL_GRACE_MS);
+}
+
+/**
+ * Add hook event compatibility env vars without exceeding platform env limits.
+ *
+ * @param env - Environment object to mutate
+ * @param hookEventJson - Serialized hook event payload
+ * @returns void
+ */
+function attachHookEventEnv(env: Record<string, string>, hookEventJson: string): void {
+	if (Buffer.byteLength(hookEventJson) <= MAX_HOOK_EVENT_ENV_BYTES) {
+		env.PI_HOOK_EVENT = hookEventJson;
+		return;
+	}
+
+	env.PI_HOOK_EVENT_TRUNCATED = "true";
 }
 
 /**
@@ -848,8 +867,8 @@ export async function runCommandHook(
 	const hookEventJson = JSON.stringify(eventData);
 	const commandEnv: Record<string, string> = {
 		...process.env,
-		PI_HOOK_EVENT: hookEventJson,
 	} as Record<string, string>;
+	attachHookEventEnv(commandEnv, hookEventJson);
 
 	if (handler._claudeSource) {
 		commandEnv.CLAUDE_CODE_REMOTE = process.env.CLAUDE_CODE_REMOTE ?? "false";
@@ -863,15 +882,26 @@ export async function runCommandHook(
 			return;
 		}
 
-		// shell: true is required for user-authored hook commands (pipes, redirects,
-		// env expansion). Commands come from settings.json, NOT from LLM input, so
-		// this is not an injection vector. Permission rules provide defense-in-depth.
-		const proc = spawn(handler.command, {
-			cwd,
-			env: commandEnv,
-			shell: true,
-			stdio: ["pipe", "pipe", "pipe"],
-		});
+		let proc: ChildProcess;
+		try {
+			// shell: true is required for user-authored hook commands (pipes, redirects,
+			// env expansion). Commands come from settings.json, NOT from LLM input, so
+			// this is not an injection vector. Permission rules provide defense-in-depth.
+			proc = spawn(handler.command, {
+				cwd,
+				env: commandEnv,
+				shell: true,
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+		} catch (error) {
+			const spawnError = error as NodeJS.ErrnoException;
+			resolve({
+				ok: false,
+				reason: spawnError.message || "Hook command failed to start",
+				infrastructureError: true,
+			});
+			return;
+		}
 
 		const stdout: HookOutputBuffer = { bytes: 0, text: "", truncated: false };
 		const stderr: HookOutputBuffer = { bytes: 0, text: "", truncated: false };
@@ -891,16 +921,16 @@ export async function runCommandHook(
 			resolve(result);
 		};
 
-		proc.stdout.on("data", (chunk: Buffer) => {
+		proc.stdout?.on("data", (chunk: Buffer) => {
 			appendToHookBuffer(stdout, chunk, maxBufferBytes);
 		});
-		proc.stderr.on("data", (chunk: Buffer) => {
+		proc.stderr?.on("data", (chunk: Buffer) => {
 			appendToHookBuffer(stderr, chunk, maxBufferBytes);
 		});
 
 		try {
-			proc.stdin.write(hookEventJson);
-			proc.stdin.end();
+			proc.stdin?.write(hookEventJson);
+			proc.stdin?.end();
 		} catch {
 			// Ignore stdin write errors (process may have already exited).
 		}

--- a/extensions/tmux-notify/__tests__/tmux-notify.test.ts
+++ b/extensions/tmux-notify/__tests__/tmux-notify.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { ExtensionHarness } from "../../../test-utils/extension-harness.js";
+import tmuxNotify, { createTmuxNotifyLifecycle, type TmuxStatus } from "../index.js";
+
+describe("createTmuxNotifyLifecycle", () => {
+	it("coalesces lifecycle status writes", () => {
+		const statuses: TmuxStatus[] = [];
+		const lifecycle = createTmuxNotifyLifecycle({ setStatus: (value) => statuses.push(value) });
+
+		lifecycle.onSessionStart();
+		lifecycle.onBeforeAgentStart();
+		lifecycle.onAgentStart();
+		lifecycle.onAgentEnd();
+		const inputResult = lifecycle.onInput();
+		lifecycle.onSessionShutdown();
+
+		expect(inputResult).toEqual({ action: "continue" });
+		expect(statuses).toEqual(["", "working", "done", ""]);
+	});
+});
+
+describe("tmuxNotify", () => {
+	it("does not register handlers outside tmux", async () => {
+		const savedTmux = process.env.TMUX;
+		delete process.env.TMUX;
+		try {
+			const harness = ExtensionHarness.create();
+			await harness.loadExtension(tmuxNotify);
+			expect(harness.handlers.size).toBe(0);
+		} finally {
+			if (savedTmux !== undefined) {
+				process.env.TMUX = savedTmux;
+			}
+		}
+	});
+});

--- a/scripts/patch-upstream-debug.mjs
+++ b/scripts/patch-upstream-debug.mjs
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: patch fixtures intentionally contain upstream template-literal source
+
 /**
  * Patch upstream pi-coding-agent dist files after install.
  *
@@ -10,6 +12,11 @@
  *    Without this, pi-ai's OpenRouter handler sends
  *    `reasoning: { effort: "none" }` which MiniMax rejects:
  *    "Reasoning is mandatory for this endpoint and cannot be disabled."
+ *
+ * 3. Add OpenAI Codex WebSocket payload diagnostics and preflight fallback.
+ *    Close code 1009 means the WebSocket frame was too large; pi-ai's stock
+ *    error hides the payload size and, in auto mode, fails after the socket has
+ *    already started instead of falling back to SSE.
  *
  * Runs as a postinstall hook so patches survive `bun install`.
  */
@@ -46,6 +53,124 @@ const MINIMAX_FIXED = `const completionOptions = model.reasoning
         ? { maxTokens, signal, apiKey, reasoning: "high" }
         : { maxTokens, signal, apiKey };
     const response = await completeSimple(model, { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages }, completionOptions);`;
+
+// ── Part 3: OpenAI Codex WebSocket payload diagnostics ───────────────────────
+
+const CODEX_WEBSOCKET_PATH =
+	"node_modules/@mariozechner/pi-ai/dist/providers/openai-codex-responses.js";
+
+const CODEX_WEBSOCKET_SENTINEL = "TALLOW_CODEX_WEBSOCKET_PAYLOAD_DIAGNOSTICS_PATCHED";
+
+const CODEX_WEBSOCKET_ANCHOR = `const OPENAI_BETA_RESPONSES_WEBSOCKETS = "responses_websockets=2026-02-06";
+const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
+const websocketSessionCache = new Map();
+const websocketDebugStats = new Map();`;
+
+const CODEX_WEBSOCKET_HELPERS = `const OPENAI_BETA_RESPONSES_WEBSOCKETS = "responses_websockets=2026-02-06";
+const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
+const TALLOW_WEBSOCKET_TOO_LARGE_CLOSE_CODE = 1009;
+const TALLOW_DEFAULT_WEBSOCKET_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
+const websocketSessionCache = new Map();
+const websocketDebugStats = new Map();
+const tallowWebSocketRequestPayloadStats = new WeakMap();
+// ${CODEX_WEBSOCKET_SENTINEL}
+function tallowResolveWebSocketMaxPayloadBytes() {
+    const raw = typeof process !== "undefined" ? process.env?.TALLOW_CODEX_WEBSOCKET_MAX_PAYLOAD_BYTES : undefined;
+    if (!raw)
+        return TALLOW_DEFAULT_WEBSOCKET_MAX_PAYLOAD_BYTES;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : TALLOW_DEFAULT_WEBSOCKET_MAX_PAYLOAD_BYTES;
+}
+function tallowJsonByteLength(value) {
+    return Buffer.byteLength(JSON.stringify(value), "utf-8");
+}
+function tallowFormatBytes(bytes) {
+    if (bytes >= 1024 * 1024)
+        return \`${"${(bytes / (1024 * 1024)).toFixed(2)}"} MiB\`;
+    if (bytes >= 1024)
+        return \`${"${(bytes / 1024).toFixed(1)}"} KiB\`;
+    return \`${"${bytes}"} B\`;
+}
+function tallowPayloadStats(requestBody, payloadBytes, maxPayloadBytes) {
+    return {
+        payloadBytes,
+        maxPayloadBytes,
+        inputItems: Array.isArray(requestBody.input) ? requestBody.input.length : 0,
+        hasPreviousResponseId: typeof requestBody.previous_response_id === "string",
+        previousResponseId: requestBody.previous_response_id,
+        model: requestBody.model,
+        instructionsBytes: typeof requestBody.instructions === "string" ? Buffer.byteLength(requestBody.instructions, "utf-8") : 0,
+        inputBytes: tallowJsonByteLength(requestBody.input ?? []),
+        toolBytes: tallowJsonByteLength(requestBody.tools ?? []),
+    };
+}
+function tallowLogWebSocketDiagnostic(evt, data) {
+    const logger = globalThis.__piDebugLogger;
+    if (!logger || typeof logger.log !== "function")
+        return;
+    try {
+        logger.log("model", evt, data);
+    }
+    catch { }
+}
+function tallowWebSocketTooLargeError(stats, code, reason) {
+    const codeText = typeof code === "number" ? \`WebSocket close ${"${code}"}\` : "WebSocket payload too large";
+    const reasonText = typeof reason === "string" && reason.length > 0 ? \` Reason: ${"${reason}"}.\` : "";
+    return new Error(\`${"${codeText}"}: OpenAI Codex WebSocket request payload was ${"${tallowFormatBytes(stats.payloadBytes)}"}, above the configured preflight limit of ${"${tallowFormatBytes(stats.maxPayloadBytes)}"}.${"${reasonText}"} Tallow will fall back to SSE in auto transport before the socket starts; if this appeared after the socket started, reduce context or run /compact. Diagnostics: inputItems=${"${stats.inputItems}"}, inputBytes=${"${tallowFormatBytes(stats.inputBytes)}"}, toolBytes=${"${tallowFormatBytes(stats.toolBytes)}"}.\`);
+}`;
+
+const CODEX_CLOSE_BUGGY = `function extractWebSocketCloseError(event) {
+    if (event && typeof event === "object") {
+        const code = "code" in event ? event.code : undefined;
+        const reason = "reason" in event ? event.reason : undefined;
+        const codeText = typeof code === "number" ? \` ${"${code}"}\` : "";
+        const reasonText = typeof reason === "string" && reason.length > 0 ? \` ${"${reason}"}\` : "";
+        return new Error(\`WebSocket closed${"${codeText}"}${"${reasonText}"}\`.trim());
+    }
+    return new Error("WebSocket closed");
+}`;
+
+const CODEX_CLOSE_FIXED = `function extractWebSocketCloseError(event, payloadStats) {
+    if (event && typeof event === "object") {
+        const code = "code" in event ? event.code : undefined;
+        const reason = "reason" in event ? event.reason : undefined;
+        if (code === TALLOW_WEBSOCKET_TOO_LARGE_CLOSE_CODE) {
+            const stats = payloadStats ?? {
+                payloadBytes: 0,
+                maxPayloadBytes: tallowResolveWebSocketMaxPayloadBytes(),
+                inputItems: 0,
+                inputBytes: 0,
+                toolBytes: 0,
+            };
+            tallowLogWebSocketDiagnostic("websocket_close_too_large", { ...stats, code, reason });
+            return tallowWebSocketTooLargeError(stats, code, reason);
+        }
+        const codeText = typeof code === "number" ? \` ${"${code}"}\` : "";
+        const reasonText = typeof reason === "string" && reason.length > 0 ? \` ${"${reason}"}\` : "";
+        return new Error(\`WebSocket closed${"${codeText}"}${"${reasonText}"}\`.trim());
+    }
+    return new Error("WebSocket closed");
+}`;
+
+const CODEX_PARSE_CLOSE_BUGGY = `            failed = extractWebSocketCloseError(event);`;
+const CODEX_PARSE_CLOSE_FIXED = `            failed = extractWebSocketCloseError(event, tallowWebSocketRequestPayloadStats.get(socket));`;
+
+const CODEX_SEND_BUGGY = `        socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
+        onStart();`;
+
+const CODEX_SEND_FIXED = `        const outboundPayload = { type: "response.create", ...requestBody };
+        const outboundPayloadJson = JSON.stringify(outboundPayload);
+        const outboundPayloadBytes = Buffer.byteLength(outboundPayloadJson, "utf-8");
+        const maxPayloadBytes = tallowResolveWebSocketMaxPayloadBytes();
+        const payloadStats = tallowPayloadStats(requestBody, outboundPayloadBytes, maxPayloadBytes);
+        tallowWebSocketRequestPayloadStats.set(socket, payloadStats);
+        tallowLogWebSocketDiagnostic("websocket_payload", { ...payloadStats, reused });
+        if (outboundPayloadBytes > maxPayloadBytes) {
+            tallowLogWebSocketDiagnostic("websocket_payload_preflight_too_large", { ...payloadStats, reused });
+            throw tallowWebSocketTooLargeError(payloadStats);
+        }
+        socket.send(outboundPayloadJson);
+        onStart();`;
 
 // ── Patch helpers ─────────────────────────────────────────────────────────────
 
@@ -85,6 +210,30 @@ function patchMiniMax(target) {
 	return true;
 }
 
+function patchCodexWebSocketDiagnostics(target) {
+	if (!existsSync(target)) return false;
+
+	let content = readFileSync(target, "utf-8");
+	if (content.includes(CODEX_WEBSOCKET_SENTINEL)) return false;
+	for (const expected of [
+		CODEX_WEBSOCKET_ANCHOR,
+		CODEX_CLOSE_BUGGY,
+		CODEX_PARSE_CLOSE_BUGGY,
+		CODEX_SEND_BUGGY,
+	]) {
+		if (!content.includes(expected)) return false;
+	}
+
+	content = content
+		.replace(CODEX_WEBSOCKET_ANCHOR, CODEX_WEBSOCKET_HELPERS)
+		.replace(CODEX_CLOSE_BUGGY, CODEX_CLOSE_FIXED)
+		.replace(CODEX_PARSE_CLOSE_BUGGY, CODEX_PARSE_CLOSE_FIXED)
+		.replace(CODEX_SEND_BUGGY, CODEX_SEND_FIXED);
+
+	writeFileSync(target, content);
+	return true;
+}
+
 // ── Run ───────────────────────────────────────────────────────────────────────
 
 let totalPatched = 0;
@@ -98,6 +247,11 @@ for (const target of DEBUG_TARGETS) {
 
 if (patchMiniMax(MINIMAX_COMPACTION_PATH)) {
 	console.log(`Patched MiniMax reasoning fix in ${MINIMAX_COMPACTION_PATH}`);
+	totalPatched++;
+}
+
+if (patchCodexWebSocketDiagnostics(CODEX_WEBSOCKET_PATH)) {
+	console.log(`Patched Codex WebSocket diagnostics in ${CODEX_WEBSOCKET_PATH}`);
 	totalPatched++;
 }
 

--- a/src/__tests__/fatal-errors.test.ts
+++ b/src/__tests__/fatal-errors.test.ts
@@ -139,6 +139,39 @@ describe("Fatal error handlers", () => {
 		expect(stderr).toContain("plain string rejection");
 	});
 
+	it("ignores uncaught EPIPE errors", async () => {
+		const { exitCode, stderr, crashLog } = await runCrashScenario(`
+			setTimeout(() => {
+				const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+				throw error;
+			}, 0);
+			setTimeout(() => process.exit(0), 50);
+		`);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).not.toContain("FATAL");
+		expect(stderr).not.toContain("Terminal I/O disconnected");
+		expect(crashLog).toContain("Ignored EPIPE");
+		expect(crashLog).toContain("write EPIPE");
+	});
+
+	it("ignores interactive EPIPE errors from non-stdio streams", async () => {
+		const { exitCode, stderr, crashLog } = await runCrashScenario(`
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+			setTimeout(() => {
+				const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+				throw error;
+			}, 0);
+			setTimeout(() => process.exit(0), 50);
+		`);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).not.toContain("FATAL");
+		expect(stderr).not.toContain("Terminal I/O disconnected");
+		expect(crashLog).toContain("Ignored EPIPE");
+		expect(crashLog).toContain("write EPIPE");
+	});
+
 	it("truncates very long error messages in banner", async () => {
 		const { stderr } = await runCrashScenario(`
 			throw new Error("x".repeat(1000));

--- a/src/__tests__/model-metadata-overrides.test.ts
+++ b/src/__tests__/model-metadata-overrides.test.ts
@@ -64,8 +64,10 @@ describe("applyKnownModelMetadataOverrides", () => {
 	it("corrects claude-sonnet-4-6 from 1M to 200k for anthropic and opencode providers", () => {
 		const anthropic = cloneBuiltInModel("anthropic", "claude-sonnet-4-6");
 		const opencode = cloneBuiltInModel("opencode", "claude-sonnet-4-6");
-		const antigravity = cloneBuiltInModel("google-antigravity", "claude-sonnet-4-6");
-		const registry = createRegistry([anthropic, opencode, antigravity]);
+		const unrelatedProvider = structuredClone(anthropic);
+		unrelatedProvider.provider = "google-antigravity";
+		unrelatedProvider.contextWindow = 200_000;
+		const registry = createRegistry([anthropic, opencode, unrelatedProvider]);
 
 		// Only patch entries that still carry the stale 1M value
 		const staleCount = [anthropic, opencode].filter((m) => m.contextWindow === 1_000_000).length;
@@ -75,7 +77,7 @@ describe("applyKnownModelMetadataOverrides", () => {
 		expect(applied).toBe(staleCount);
 		expect(anthropic.contextWindow).toBe(200_000);
 		expect(opencode.contextWindow).toBe(200_000);
-		// google-antigravity already has 200k — never touched
-		expect(antigravity.contextWindow).toBe(200_000);
+		// unrelated providers are never touched
+		expect(unrelatedProvider.contextWindow).toBe(200_000);
 	});
 });

--- a/src/__tests__/process-cleanup.test.ts
+++ b/src/__tests__/process-cleanup.test.ts
@@ -100,6 +100,21 @@ describe("registerProcessCleanup", () => {
 		expect(exitCode).toBe(130);
 	});
 
+	test("ignores EPIPE from interactive stdout", async () => {
+		const { exitCode, stdout } = await runCleanupScenario(`
+			registerProcessCleanup();
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+			process.stdout.emit("error", Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+			setTimeout(() => {
+				process.stdout.write("still-alive");
+				process.exit(0);
+			}, 50);
+		`);
+
+		expect(exitCode).toBe(0);
+		expect(stdout).toContain("still-alive");
+	});
+
 	test("second signal during cleanup forces immediate exit", async () => {
 		// Send two SIGTERMs in rapid succession — the second should force-exit
 		const { exitCode } = await runCleanupScenario(`

--- a/src/fatal-errors.ts
+++ b/src/fatal-errors.ts
@@ -19,6 +19,51 @@ const CRASH_LOG = join(TALLOW_HOME, "crash.log");
 /** Guard against recursive or duplicate fatal error handling. */
 let handled = false;
 
+/** Terminal I/O error codes emitted when a TTY or pipe disappears. */
+const TERMINAL_IO_ERROR_CODES = new Set(["EIO", "EPIPE"]);
+
+/**
+ * Get the terminal I/O code reported by an error, if any.
+ *
+ * @param error - The error to classify
+ * @returns The terminal I/O code, or undefined for unrelated errors
+ */
+function getTerminalIoErrorCode(error: Error): "EIO" | "EPIPE" | undefined {
+	const code = (error as NodeJS.ErrnoException).code;
+	if (code === "EIO" || code === "EPIPE") return code;
+
+	const match = /^(?:read|write) (EIO|EPIPE)$/.exec(error.message);
+	return match?.[1] as "EIO" | "EPIPE" | undefined;
+}
+
+/**
+ * Determine whether an error only reports a disconnected terminal or pipe.
+ *
+ * @param error - The error to classify
+ * @returns True when the error is an expected terminal I/O disconnect
+ */
+function isTerminalIoError(error: Error): boolean {
+	const code = getTerminalIoErrorCode(error);
+	return Boolean(code && TERMINAL_IO_ERROR_CODES.has(code));
+}
+
+/**
+ * Write to a process stream without recursively crashing on terminal I/O errors.
+ *
+ * @param stream - The stream to write to
+ * @param data - The bytes or text to write
+ * @returns True when the write was attempted without a synchronous throw
+ */
+function safeWrite(stream: NodeJS.WriteStream, data: string): boolean {
+	try {
+		stream.write(data);
+		return true;
+	} catch (err) {
+		if (err instanceof Error && isTerminalIoError(err)) return false;
+		throw err;
+	}
+}
+
 /**
  * Append a timestamped crash entry to the persistent crash log.
  *
@@ -52,7 +97,7 @@ function writeCrashLog(type: string, error: Error): void {
 function displayFatalBanner(type: string, error: Error): void {
 	// Restore terminal so the banner is visible after TUI alternate screen
 	if (process.stdout.isTTY) {
-		process.stdout.write("\x1b[?1049l\x1b[?25h");
+		safeWrite(process.stdout, "\x1b[?1049l\x1b[?25h");
 	}
 
 	const message = error.message.length > 500 ? `${error.message.slice(0, 500)}…` : error.message;
@@ -75,7 +120,16 @@ function displayFatalBanner(type: string, error: Error): void {
 		"",
 	];
 
-	process.stderr.write(lines.join("\n"));
+	safeWrite(process.stderr, lines.join("\n"));
+}
+
+/**
+ * Display a short disconnect notice without using alternate-screen recovery.
+ *
+ * @param error - The terminal I/O error that forced shutdown
+ */
+function displayTerminalIoNotice(error: Error): void {
+	safeWrite(process.stderr, `\nTerminal I/O disconnected (${error.message}); exiting.\n`);
 }
 
 /**
@@ -91,6 +145,19 @@ function displayFatalBanner(type: string, error: Error): void {
 function handleFatal(type: string, error: Error): void {
 	if (handled) return;
 	handled = true;
+
+	const terminalIoCode = getTerminalIoErrorCode(error);
+	if (terminalIoCode === "EPIPE") {
+		writeCrashLog("Ignored EPIPE", error);
+		handled = false;
+		return;
+	}
+	if (terminalIoCode === "EIO") {
+		writeCrashLog("Terminal I/O disconnected", error);
+		displayTerminalIoNotice(error);
+		process.nextTick(() => process.exit(1));
+		return;
+	}
 
 	writeCrashLog(type, error);
 	displayFatalBanner(type, error);

--- a/src/process-cleanup.ts
+++ b/src/process-cleanup.ts
@@ -71,6 +71,9 @@ function handleStreamError(
 	sessionRef: { current?: AgentSession }
 ): void {
 	stream.on("error", (err: NodeJS.ErrnoException) => {
+		if (err.code === "EPIPE" && stream.isTTY) {
+			return;
+		}
 		if (err.code === "EIO" || err.code === "EPIPE") {
 			void cleanup(sessionRef.current, 1);
 		}


### PR DESCRIPTION
## Summary
- Add Codex WebSocket payload diagnostics and preflight SSE fallback for oversized requests
- Keep oversized hook event payloads out of subprocess env vars
- Ignore benign terminal EPIPE disconnects while preserving EIO handling

## Changes Made
- Patch pi-ai Codex WebSocket transport during postinstall to log payload sizes and classify close code 1009
- Send hook event JSON via stdin with env compatibility truncation marker
- Harden fatal/process cleanup paths for disconnected pipe errors

## Testing
- bun test extensions/hooks/__tests__/subprocess-hardening.test.ts src/__tests__/fatal-errors.test.ts src/__tests__/process-cleanup.test.ts
- bun run typecheck
- bun run typecheck:extensions
- bun run lint
- bun run test:docs